### PR TITLE
Fix MCLeaks detection

### DIFF
--- a/en_US.yml
+++ b/en_US.yml
@@ -71,6 +71,10 @@ inventory:
     freezing: "Freezing %name%"
     active_detection: "See active detection for %name%"
     see_alerts: "See all alerts for %name%"
+    mcleaks_indicator:
+      positive: "&cIs using MCLeaks"
+      negative: "&aIs not using MCLeaks"
+      description: "&7MCLeaks provides premium accounts for free"
   detection:
     name_inv: "Active detection"
     no_active: "No active detection for %name%"

--- a/fr_FR.yml
+++ b/fr_FR.yml
@@ -71,6 +71,10 @@ inventory:
     freezing: "Geler %name%"
     active_detection: "Voir les détéctions active pour %name%"
     see_alerts: "Voir les alertes de %name%"
+    mcleaks_indicator:
+      positive: "&cUtilise MCLeaks"
+      negative: "&aN'utilise pas MCLeaks"
+      description: "&7MCLeaks fournit des comptes premiums gratuitement"
   detection:
     name_inv: "Detection active"
     no_active: "Aucune detection active pour %name%"

--- a/src/assets/negativity/en_US.yml
+++ b/src/assets/negativity/en_US.yml
@@ -78,6 +78,11 @@ inventory {
     freezing: "Freezing %name%"
     active_detection: "See active detection for %name%"
     see_alerts: "See all alerts for %name%"
+    mcleaks_indicator {
+      positive: "&cIs using MCLeaks"
+      negative: "&aIs not using MCLeaks"
+      description: "&7MCLeaks provides premium accounts for free"
+    }
   }
   detection {
     name_inv: "Active detection"

--- a/src/assets/negativity/fr_FR.yml
+++ b/src/assets/negativity/fr_FR.yml
@@ -78,6 +78,11 @@ inventory {
     freezing: "Geler %name%"
     active_detection: "Voir les détéctions active pour %name%"
     see_alerts: "Voir les alertes de %name%"
+    mcleaks_indicator {
+      positive: "&cUtilise MCLeaks"
+      negative: "&aN'utilise pas MCLeaks"
+      description: "&7MCLeaks fournit des comptes premiums gratuitement"
+    }
   }
   detection {
     name_inv: "Detection active"

--- a/src/com/elikill58/negativity/spigot/inventories/CheckMenuInventory.java
+++ b/src/com/elikill58/negativity/spigot/inventories/CheckMenuInventory.java
@@ -1,6 +1,6 @@
 package com.elikill58.negativity.spigot.inventories;
 
-import java.util.Arrays;
+import java.util.Collections;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -33,7 +33,7 @@ public class CheckMenuInventory {
 		inv.setItem(9, Utils.createItem(Material.DIAMOND_SWORD, "Fight: " + Messages.getMessage(p, "inventory.manager." + (np.MODS.size() > 0 ? "enabled" : "disabled"))));
 		inv.setItem(10, Utils.createItem(Material.DIAMOND_PICKAXE, "Minerate", np.mineRate.getInventoryLoreString()));
 		inv.setItem(11, Utils.createItem(Material.GRASS, ChatColor.RESET + "Mods", ChatColor.GRAY + "Forge: " + Messages.getMessage(p, "inventory.manager." + (np.MODS.size() > 0 ? "enabled" : "disabled"))));
-		inv.setItem(12, getWoolItem(np.isMcLeaks()));
+		inv.setItem(12, getWoolItem(p, np.isMcLeaks()));
 		inv.setItem(13, Utils.createItem(Utils.getMaterialWith1_15_Compatibility("SKELETON_SKULL", "SKULL_ITEM", "LEGACY_SKULL_ITEM"), Messages.getMessage(p, "fake_entities")));
 		//inv.setItem(16, Utils.createItem(Utils.getMaterialWith1_13_Compatibility("DIAMOND_SPADE", "LEGACY_DIAMOND_SPADE"), "Kick"));
 		//inv.setItem(17, Utils.createItem(Material.ANVIL, "Ban"));
@@ -62,7 +62,7 @@ public class CheckMenuInventory {
 			inv.setItem(9, Utils.createItem(Material.DIAMOND_SWORD, "Fight: " + Messages.getMessage(p, "inventory.manager." + (np.MODS.size() > 0 ? "enabled" : "disabled"))));
 			p.updateInventory();
 		} catch (ArrayIndexOutOfBoundsException e) {
-			
+		
 		}
 	}
 	
@@ -76,13 +76,13 @@ public class CheckMenuInventory {
 	}
 	
 	@SuppressWarnings("deprecation")
-	private static ItemStack getWoolItem(boolean b) {
+	private static ItemStack getWoolItem(Player player, boolean b) {
 		ItemStack item = new ItemStack(Utils.getMaterialWith1_15_Compatibility((b ? "RED_WOOL" : "LIME_WOOL"), "WOOL"));
 		if(item.getType().name().equals("WOOL"))
 			item.setDurability((short) (b ? 14 : 5));
 		ItemMeta meta = item.getItemMeta();
-		meta.setDisplayName(ChatColor.RESET + "McLeaks: " + (b ? ChatColor.RED + "Yes" : ChatColor.GREEN + "No"));
-		meta.setLore(Arrays.asList(ChatColor.GRAY + "McLeak is a", ChatColor.GRAY + "Generator of account"));
+		meta.setDisplayName(Messages.getMessage(player, "inventory.main.mcleaks_indicator." + (b ? "positive" : "negative")));
+		meta.setLore(Collections.singletonList(Messages.getMessage(player, "inventory.main.mcleaks_indicator.description")));
 		item.setItemMeta(meta);
 		return item;
 	}
@@ -137,6 +137,6 @@ public class CheckMenuInventory {
 			default:
 				break;
 			}
-		}		
+		}
 	}
 }

--- a/src/com/elikill58/negativity/sponge/Inv.java
+++ b/src/com/elikill58/negativity/sponge/Inv.java
@@ -1,7 +1,7 @@
 package com.elikill58.negativity.sponge;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -22,7 +22,6 @@ import org.spongepowered.api.item.inventory.property.InventoryTitle;
 import org.spongepowered.api.item.inventory.query.QueryOperationTypes;
 import org.spongepowered.api.item.inventory.type.GridInventory;
 import org.spongepowered.api.text.Text;
-import org.spongepowered.api.text.format.TextColors;
 
 import com.elikill58.negativity.sponge.utils.Utils;
 import com.elikill58.negativity.universal.Cheat;
@@ -78,7 +77,7 @@ public class Inv {
 		invGrid.set(1, 1, Utils.createItem(ItemTypes.DIAMOND_PICKAXE, "&rMinerate", np.mineRate.getInventoryLoreString()));
 		invGrid.set(2, 1, Utils.createItem(ItemTypes.GRASS, "&rMods", "&7Forge: "
 				+ Messages.getStringMessage(p, "inventory.manager." + (np.MODS.size() > 0 ? "enabled" : "disabled"))));
-		invGrid.set(3, 1, getMcLeaksIndicator(np));
+		invGrid.set(3, 1, getMcLeaksIndicator(p, np));
 		/*if(Cheat.forKey("FORCEFIELD").get().isActive() && !SpongeNegativity.getConfig().getNode("cheats").getNode("forcefield").getNode("ghost_disabled").getBoolean())
 			invGrid.set(3, 1, Utils.createItem(ItemTypes.SKULL, "&rFake entities"));*/
 
@@ -97,19 +96,12 @@ public class Inv {
 		CHECKING.put(p, cible);
 	}
 	
-	private static ItemStack getMcLeaksIndicator(NegativityPlayer player) {
+	private static ItemStack getMcLeaksIndicator(Player player, NegativityPlayer nPlayer) {
 		ItemStack indicator = ItemStack.of(ItemTypes.WOOL);
-		boolean hasMcLeaks = player.isMcLeaks();
-		Text indicatorYesNoText;
-		if (hasMcLeaks) {
-			indicatorYesNoText = Text.of(TextColors.RED, "Yes");
-			indicator.offer(Keys.DYE_COLOR, DyeColors.RED);
-		} else {
-			indicatorYesNoText = Text.of(TextColors.GREEN, "No");
-			indicator.offer(Keys.DYE_COLOR, DyeColors.LIME);
-		}
-		indicator.offer(Keys.DISPLAY_NAME, Text.of("Uses MCLeaks: ", indicatorYesNoText));
-		indicator.offer(Keys.ITEM_LORE, Arrays.asList(Text.of(TextColors.GRAY, "MCLeak is a generator of account")));
+		boolean usesMcLeaks = nPlayer.isMcLeaks();
+		indicator.offer(Keys.DYE_COLOR, usesMcLeaks ? DyeColors.RED : DyeColors.LIME);
+		indicator.offer(Keys.DISPLAY_NAME, Messages.getMessage(player, "inventory.main.mcleaks_indicator." + (usesMcLeaks ? "positive" : "negative")));
+		indicator.offer(Keys.ITEM_LORE, Collections.singletonList(Messages.getMessage(player, "inventory.main.mcleaks_indicator.description")));
 		return indicator;
 	}
 

--- a/src/com/elikill58/negativity/sponge/Inv.java
+++ b/src/com/elikill58/negativity/sponge/Inv.java
@@ -1,6 +1,7 @@
 package com.elikill58.negativity.sponge;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -21,9 +22,11 @@ import org.spongepowered.api.item.inventory.property.InventoryTitle;
 import org.spongepowered.api.item.inventory.query.QueryOperationTypes;
 import org.spongepowered.api.item.inventory.type.GridInventory;
 import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.format.TextColors;
 
 import com.elikill58.negativity.sponge.utils.Utils;
 import com.elikill58.negativity.universal.Cheat;
+import com.elikill58.negativity.universal.NegativityPlayer;
 import com.elikill58.negativity.universal.adapter.Adapter;
 import com.elikill58.negativity.universal.permissions.Perm;
 
@@ -75,6 +78,7 @@ public class Inv {
 		invGrid.set(1, 1, Utils.createItem(ItemTypes.DIAMOND_PICKAXE, "&rMinerate", np.mineRate.getInventoryLoreString()));
 		invGrid.set(2, 1, Utils.createItem(ItemTypes.GRASS, "&rMods", "&7Forge: "
 				+ Messages.getStringMessage(p, "inventory.manager." + (np.MODS.size() > 0 ? "enabled" : "disabled"))));
+		invGrid.set(3, 1, getMcLeaksIndicator(np));
 		/*if(Cheat.forKey("FORCEFIELD").get().isActive() && !SpongeNegativity.getConfig().getNode("cheats").getNode("forcefield").getNode("ghost_disabled").getBoolean())
 			invGrid.set(3, 1, Utils.createItem(ItemTypes.SKULL, "&rFake entities"));*/
 
@@ -91,6 +95,22 @@ public class Inv {
 		invGrid.set(8, 2, Utils.createItem(ItemTypes.BARRIER, Messages.getStringMessage(p, "inventory.close")));
 		p.openInventory(inv);
 		CHECKING.put(p, cible);
+	}
+	
+	private static ItemStack getMcLeaksIndicator(NegativityPlayer player) {
+		ItemStack indicator = ItemStack.of(ItemTypes.WOOL);
+		boolean hasMcLeaks = player.isMcLeaks();
+		Text indicatorYesNoText;
+		if (hasMcLeaks) {
+			indicatorYesNoText = Text.of(TextColors.RED, "Yes");
+			indicator.offer(Keys.DYE_COLOR, DyeColors.RED);
+		} else {
+			indicatorYesNoText = Text.of(TextColors.GREEN, "No");
+			indicator.offer(Keys.DYE_COLOR, DyeColors.LIME);
+		}
+		indicator.offer(Keys.DISPLAY_NAME, Text.of("Uses MCLeaks: ", indicatorYesNoText));
+		indicator.offer(Keys.ITEM_LORE, Arrays.asList(Text.of(TextColors.GRAY, "MCLeak is a generator of account")));
+		return indicator;
 	}
 
 	public static void actualizeCheckMenu(Player p, Player cible) {

--- a/src/com/elikill58/negativity/universal/NegativityPlayer.java
+++ b/src/com/elikill58/negativity/universal/NegativityPlayer.java
@@ -11,7 +11,9 @@ public abstract class NegativityPlayer {
 
 	public NegativityPlayer(UUID playerId) {
 		this.playerId = playerId;
-		this.isMcLeaks = Adapter.getAdapter().isUsingMcLeaks(playerId);
+		Adapter.getAdapter().isUsingMcLeaks(playerId).thenAccept(isUsingMcLeaks -> {
+			this.isMcLeaks = isUsingMcLeaks;
+		});
 	}
 
 	public NegativityAccount getAccount() {

--- a/src/com/elikill58/negativity/universal/NegativityPlayer.java
+++ b/src/com/elikill58/negativity/universal/NegativityPlayer.java
@@ -3,7 +3,6 @@ package com.elikill58.negativity.universal;
 import java.util.UUID;
 
 import com.elikill58.negativity.universal.adapter.Adapter;
-import com.elikill58.negativity.universal.utils.UniversalUtils;
 
 public abstract class NegativityPlayer {
 
@@ -12,7 +11,7 @@ public abstract class NegativityPlayer {
 
 	public NegativityPlayer(UUID playerId) {
 		this.playerId = playerId;
-		this.isMcLeaks = UniversalUtils.isMcleaks(playerId.toString());
+		this.isMcLeaks = Adapter.getAdapter().isUsingMcLeaks(playerId);
 	}
 
 	public NegativityAccount getAccount() {

--- a/src/com/elikill58/negativity/universal/adapter/Adapter.java
+++ b/src/com/elikill58/negativity/universal/adapter/Adapter.java
@@ -5,6 +5,7 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -64,5 +65,5 @@ public abstract class Adapter {
 	public abstract void invalidateAccount(UUID playerId);
 	public abstract void alertMod(ReportType type, Object p, Cheat c, int reliability, String proof, String hover_proof);
 	public abstract void runConsoleCommand(String cmd);
-	public abstract boolean isUsingMcLeaks(UUID playerId);
+	public abstract CompletableFuture<Boolean> isUsingMcLeaks(UUID playerId);
 }

--- a/src/com/elikill58/negativity/universal/adapter/Adapter.java
+++ b/src/com/elikill58/negativity/universal/adapter/Adapter.java
@@ -64,4 +64,5 @@ public abstract class Adapter {
 	public abstract void invalidateAccount(UUID playerId);
 	public abstract void alertMod(ReportType type, Object p, Cheat c, int reliability, String proof, String hover_proof);
 	public abstract void runConsoleCommand(String cmd);
+	public abstract boolean isUsingMcLeaks(UUID playerId);
 }

--- a/src/com/elikill58/negativity/universal/adapter/BungeeAdapter.java
+++ b/src/com/elikill58/negativity/universal/adapter/BungeeAdapter.java
@@ -10,6 +10,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.logging.Level;
 
@@ -27,7 +28,9 @@ import com.elikill58.negativity.universal.TranslatedMessages;
 import com.elikill58.negativity.universal.translation.CachingTranslationProvider;
 import com.elikill58.negativity.universal.translation.TranslationProvider;
 import com.elikill58.negativity.universal.translation.TranslationProviderFactory;
+import com.elikill58.negativity.universal.utils.UniversalUtils;
 import com.google.common.io.ByteStreams;
+import com.google.gson.Gson;
 
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
@@ -244,5 +247,21 @@ public class BungeeAdapter extends Adapter implements TranslationProviderFactory
 	@Override
 	public void runConsoleCommand(String cmd) {
 		pl.getProxy().getPluginManager().dispatchCommand(pl.getProxy().getConsole(), cmd);
+	}
+
+	@Override
+	public boolean isUsingMcLeaks(UUID playerId) {
+		try {
+			String response = UniversalUtils.requestMcleaksData(playerId.toString());
+			Gson gson = new Gson();
+			Map<?, ?> data = gson.fromJson(response, Map.class);
+			Object isMcleaks = data.get("isMcleaks");
+			if (isMcleaks != null) {
+				return Boolean.parseBoolean(isMcleaks.toString());
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		return false;
 	}
 }

--- a/src/com/elikill58/negativity/universal/adapter/BungeeAdapter.java
+++ b/src/com/elikill58/negativity/universal/adapter/BungeeAdapter.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 
 import javax.annotation.Nonnull;
@@ -250,18 +251,22 @@ public class BungeeAdapter extends Adapter implements TranslationProviderFactory
 	}
 
 	@Override
-	public boolean isUsingMcLeaks(UUID playerId) {
-		try {
-			String response = UniversalUtils.requestMcleaksData(playerId.toString());
-			Gson gson = new Gson();
-			Map<?, ?> data = gson.fromJson(response, Map.class);
-			Object isMcleaks = data.get("isMcleaks");
-			if (isMcleaks != null) {
-				return Boolean.parseBoolean(isMcleaks.toString());
+	public CompletableFuture<Boolean> isUsingMcLeaks(UUID playerId) {
+		return UniversalUtils.requestMcleaksData(playerId.toString()).thenApply(response -> {
+			if (response == null) {
+				return false;
 			}
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
-		return false;
+			try {
+				Gson gson = new Gson();
+				Map<?, ?> data = gson.fromJson(response, Map.class);
+				Object isMcleaks = data.get("isMcleaks");
+				if (isMcleaks != null) {
+					return Boolean.parseBoolean(isMcleaks.toString());
+				}
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+			return false;
+		});
 	}
 }

--- a/src/com/elikill58/negativity/universal/adapter/SpigotAdapter.java
+++ b/src/com/elikill58/negativity/universal/adapter/SpigotAdapter.java
@@ -24,6 +24,8 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
 
 import com.elikill58.negativity.spigot.SpigotNegativity;
 import com.elikill58.negativity.spigot.SpigotNegativityPlayer;
@@ -275,5 +277,23 @@ public class SpigotAdapter extends Adapter implements TranslationProviderFactory
 	@Override
 	public void invalidateAccount(UUID playerId) {
 		account.remove(playerId);
+	}
+
+	@Override
+	public boolean isUsingMcLeaks(UUID playerId) {
+		try {
+			String response = UniversalUtils.requestMcleaksData(playerId.toString());
+			Object data = new JSONParser().parse(response);
+			if (data instanceof JSONObject) {
+				JSONObject json = (JSONObject) data;
+				Object isMcleaks = json.get("isMcleaks");
+				if (isMcleaks != null) {
+					return Boolean.getBoolean(isMcleaks.toString());
+				}
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		return false;
 	}
 }

--- a/src/com/elikill58/negativity/universal/adapter/SpongeAdapter.java
+++ b/src/com/elikill58/negativity/universal/adapter/SpongeAdapter.java
@@ -1,7 +1,9 @@
 package com.elikill58.negativity.universal.adapter;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.StringReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -42,6 +44,7 @@ import com.google.common.cache.LoadingCache;
 
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.commented.CommentedConfigurationNode;
+import ninja.leaping.configurate.gson.GsonConfigurationLoader;
 import ninja.leaping.configurate.hocon.HoconConfigurationLoader;
 
 public class SpongeAdapter extends Adapter implements TranslationProviderFactory {
@@ -334,5 +337,20 @@ public class SpongeAdapter extends Adapter implements TranslationProviderFactory
 	@Override
 	public void runConsoleCommand(String cmd) {
 		Sponge.getCommandManager().process(Sponge.getServer().getConsole(), cmd);
+	}
+
+	@Override
+	public boolean isUsingMcLeaks(UUID playerId) {
+		try {
+			String response = UniversalUtils.requestMcleaksData(playerId.toString());
+			ConfigurationNode rootNode = GsonConfigurationLoader.builder()
+					.setSource(() -> new BufferedReader(new StringReader(response)))
+					.build()
+					.load();
+			return rootNode.getNode("isMcleaks").getBoolean(false);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		return false;
 	}
 }

--- a/src/com/elikill58/negativity/universal/adapter/VelocityAdapter.java
+++ b/src/com/elikill58/negativity/universal/adapter/VelocityAdapter.java
@@ -13,6 +13,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -28,9 +29,11 @@ import com.elikill58.negativity.universal.TranslatedMessages;
 import com.elikill58.negativity.universal.translation.CachingTranslationProvider;
 import com.elikill58.negativity.universal.translation.TranslationProvider;
 import com.elikill58.negativity.universal.translation.TranslationProviderFactory;
+import com.elikill58.negativity.universal.utils.UniversalUtils;
 import com.elikill58.negativity.velocity.VelocityNegativity;
 import com.elikill58.negativity.velocity.VelocityNegativityPlayer;
 import com.google.common.io.ByteStreams;
+import com.google.gson.Gson;
 import com.velocitypowered.api.proxy.Player;
 
 import net.md_5.bungee.config.Configuration;
@@ -244,5 +247,21 @@ public class VelocityAdapter extends Adapter implements TranslationProviderFacto
 	@Override
 	public void runConsoleCommand(String cmd) {
 		pl.getServer().getCommandManager().execute(pl.getServer().getConsoleCommandSource(), cmd);
+	}
+
+	@Override
+	public boolean isUsingMcLeaks(UUID playerId) {
+		try {
+			String response = UniversalUtils.requestMcleaksData(playerId.toString());
+			Gson gson = new Gson();
+			Map<?, ?> data = gson.fromJson(response, Map.class);
+			Object isMcleaks = data.get("isMcleaks");
+			if (isMcleaks != null) {
+				return Boolean.parseBoolean(isMcleaks.toString());
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		return false;
 	}
 }

--- a/src/com/elikill58/negativity/universal/adapter/VelocityAdapter.java
+++ b/src/com/elikill58/negativity/universal/adapter/VelocityAdapter.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -248,20 +249,24 @@ public class VelocityAdapter extends Adapter implements TranslationProviderFacto
 	public void runConsoleCommand(String cmd) {
 		pl.getServer().getCommandManager().execute(pl.getServer().getConsoleCommandSource(), cmd);
 	}
-
+	
 	@Override
-	public boolean isUsingMcLeaks(UUID playerId) {
-		try {
-			String response = UniversalUtils.requestMcleaksData(playerId.toString());
-			Gson gson = new Gson();
-			Map<?, ?> data = gson.fromJson(response, Map.class);
-			Object isMcleaks = data.get("isMcleaks");
-			if (isMcleaks != null) {
-				return Boolean.parseBoolean(isMcleaks.toString());
+	public CompletableFuture<Boolean> isUsingMcLeaks(UUID playerId) {
+		return UniversalUtils.requestMcleaksData(playerId.toString()).thenApply(response -> {
+			if (response == null) {
+				return false;
 			}
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
-		return false;
+			try {
+				Gson gson = new Gson();
+				Map<?, ?> data = gson.fromJson(response, Map.class);
+				Object isMcleaks = data.get("isMcleaks");
+				if (isMcleaks != null) {
+					return Boolean.parseBoolean(isMcleaks.toString());
+				}
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+			return false;
+		});
 	}
 }

--- a/src/com/elikill58/negativity/universal/utils/UniversalUtils.java
+++ b/src/com/elikill58/negativity/universal/utils/UniversalUtils.java
@@ -24,9 +24,6 @@ import javax.net.ssl.SSLSession;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
-
 import com.elikill58.negativity.universal.Database;
 import com.elikill58.negativity.universal.DefaultConfigValue;
 import com.elikill58.negativity.universal.SuspectManager;
@@ -138,33 +135,21 @@ public class UniversalUtils {
 		}
 	}
 	
-	public static boolean isMcleaks(String uuid) {
-		try {
-			URL url = new URL("https://mcleaks.themrgong.xyz/api/v3/isuuidmcleaks/" + uuid);
-			doTrustToCertificates();
-			HttpsURLConnection connection = (HttpsURLConnection) url.openConnection();
-			/*
-			 * connection.setConnectTimeout(5); connection.setReadTimeout(5);
-			 */
-			connection.setRequestProperty("User-Agent", "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.4; en-US; rv:1.9.2.2) Gecko/20100316 Firefox/3.6.2");
-			connection.setUseCaches(true);
-			connection.setDoOutput(true);
-			BufferedReader br = new BufferedReader(new InputStreamReader(connection.getInputStream()));
-			String content = "";
+	public static String requestMcleaksData(String uuid) throws Exception {
+		URL url = new URL("https://mcleaks.themrgong.xyz/api/v3/isuuidmcleaks/" + uuid);
+		doTrustToCertificates();
+		HttpsURLConnection connection = (HttpsURLConnection) url.openConnection();
+		connection.setRequestProperty("User-Agent", "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.4; en-US; rv:1.9.2.2) Gecko/20100316 Firefox/3.6.2");
+		connection.setUseCaches(true);
+		connection.setDoOutput(true);
+		try (BufferedReader br = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
+			StringBuilder content = new StringBuilder();
 			String input;
-			while ((input = br.readLine()) != null)
-				content = content + input;
-			br.close();
-			Object data = new JSONParser().parse(content);
-			if(data instanceof JSONObject) {
-				JSONObject json = (JSONObject) data;
-				if(json.containsKey("isMcleaks"))
-					return Boolean.getBoolean(json.get("isMcleaks").toString());
+			while ((input = br.readLine()) != null) {
+				content.append(input);
 			}
-		} catch (Exception exc) {
-			exc.printStackTrace();
+			return content.toString();
 		}
-        return false;
 	}
 
 	public static boolean isValidIP(String ip) {

--- a/src/com/elikill58/negativity/universal/utils/UniversalUtils.java
+++ b/src/com/elikill58/negativity/universal/utils/UniversalUtils.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.jar.JarEntry;
 import java.util.jar.JarInputStream;
 
@@ -23,6 +24,8 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import com.elikill58.negativity.universal.Database;
 import com.elikill58.negativity.universal.DefaultConfigValue;
@@ -135,21 +138,28 @@ public class UniversalUtils {
 		}
 	}
 	
-	public static String requestMcleaksData(String uuid) throws Exception {
-		URL url = new URL("https://mcleaks.themrgong.xyz/api/v3/isuuidmcleaks/" + uuid);
-		doTrustToCertificates();
-		HttpsURLConnection connection = (HttpsURLConnection) url.openConnection();
-		connection.setRequestProperty("User-Agent", "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.4; en-US; rv:1.9.2.2) Gecko/20100316 Firefox/3.6.2");
-		connection.setUseCaches(true);
-		connection.setDoOutput(true);
-		try (BufferedReader br = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
-			StringBuilder content = new StringBuilder();
-			String input;
-			while ((input = br.readLine()) != null) {
-				content.append(input);
+	public static CompletableFuture<@Nullable String> requestMcleaksData(String uuid) {
+		return CompletableFuture.supplyAsync(() -> {
+			try {
+				URL url = new URL("https://mcleaks.themrgong.xyz/api/v3/isuuidmcleaks/" + uuid);
+				doTrustToCertificates();
+				HttpsURLConnection connection = (HttpsURLConnection) url.openConnection();
+				connection.setRequestProperty("User-Agent", "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.4; en-US; rv:1.9.2.2) Gecko/20100316 Firefox/3.6.2");
+				connection.setUseCaches(true);
+				connection.setDoOutput(true);
+				try (BufferedReader br = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
+					StringBuilder content = new StringBuilder();
+					String input;
+					while ((input = br.readLine()) != null) {
+						content.append(input);
+					}
+					return content.toString();
+				}
+			} catch (Exception e) {
+				e.printStackTrace();
 			}
-			return content.toString();
-		}
+			return null;
+		});
 	}
 
 	public static boolean isValidIP(String ip) {


### PR DESCRIPTION
The MCLeaks detection only works on Spigot, other platforms (including proxies) throw a CNFE when a player joins because the JSON Simple library isn't necessarily present there.

Another issue is that the detections uses a synchrounous HTTP request, that delays the server join and idles the whole server each time a player joins. This PR also fixes that.

The PR also translates the text of the negativity menu and implements the indicator for the Sponge plugin.