### PR TITLE
Add a new BanProcessor that forwards bans to proxies

### DIFF
--- a/bungee_config.yml
+++ b/bungee_config.yml
@@ -60,3 +60,48 @@ Translation:
   # The provider used to get translated messages, useful if you want to customize the way Negativity gets its messages.
   # The only one available out-of-the-box is "platform".
   provider: platform
+
+# Configuration of the bans subsystem. For more information
+# see https://github.com/Elikill58/Negativity/wiki/Bans
+ban:
+  active: false
+  # Processors manage bans. Only one processor can be used at the time.
+  # Available processors :
+  # - file : Saves bans under the ban/ directory of the configuration directory
+  # - database : Saves bans in a database. Needs a configured database (see the Database category)
+  # - command : Runs commands to ban or unban
+  # Defaults to "file"
+  processor: "file"
+  # Commands to execute when using the "command" processor
+  # You can execute as many commands as you want. Order is respected.
+  #
+  # Available placeholders:
+  # %uuid% : uuid of banned player
+  # %name% : name of banned player
+  # %ip% : ip of the banned player
+  # %reason% : detected cheat
+  # %alert% : number of alerts for the detected cheat that triggered the ban
+  # %all_alert% : all alerts for the detected cheat since you added Negativity on your server
+  command:
+    ban:
+    - "/ban %uuid% %reason%"
+    unban:
+    - "/unban %uuid% %reason%"
+  # Need to be banned
+  reliability_need: 95
+  alert_need: 10
+  # How to calculate the time during the player will be banned
+  # IN MILLISECONDES
+  time:
+    # %reliability% : reliability of last alert
+    # %alert% : number of alert sent
+    calculator: "360000000 + (%reliability% * 20 * %alert%)"
+  def:
+    # Number that you need to be ban definitly
+    ban_time: 2
+  file:
+    # Log expired or revoked bans when using the "file" processor
+    log_bans: true
+  database:
+    # Log expired or revoked bans when using the "database" processor
+    log_bans: true

--- a/config.yml
+++ b/config.yml
@@ -211,6 +211,8 @@ ban:
   # - database : Saves bans in a database. Needs a configured database (see the Database category)
   # - command : Runs commands to ban or unban
   # - bukkit : Uses Bukkit's ban system
+  # - proxy : Forwards ban execution and revocations to the proxy companion plugin.
+  #   You must enable bans on the proxy plugin's configuration for it to work
   # The following plugins are also supported :
   # - maxbans
   # - advancedban

--- a/src/assets/negativity/config.conf
+++ b/src/assets/negativity/config.conf
@@ -245,6 +245,8 @@ ban {
   # - database : Saves bans in a database. Needs a configured database (see the Database category)
   # - command : Runs commands to ban or unban
   # - sponge : Uses Sponge's BanService
+  # - proxy : Forwards ban execution and revocations to the proxy companion plugin.
+  #   You must enable bans on the proxy plugin's configuration for it to work
   # Defaults to "file"
   processor: "file"
   # Commands to execute when using the "command" processor

--- a/src/com/elikill58/negativity/bungee/BungeeMessages.java
+++ b/src/com/elikill58/negativity/bungee/BungeeMessages.java
@@ -1,5 +1,7 @@
 package com.elikill58.negativity.bungee;
 
+import java.util.UUID;
+
 import com.elikill58.negativity.universal.TranslatedMessages;
 
 import net.md_5.bungee.api.ChatColor;
@@ -10,7 +12,11 @@ import net.md_5.bungee.api.connection.ProxiedPlayer;
 public class BungeeMessages {
 
 	public static String getMessage(ProxiedPlayer p, String dir, Object... placeholders) {
-		String message = TranslatedMessages.getStringFromLang(TranslatedMessages.getLang(p.getUniqueId()), dir, placeholders);
+		return getMessage(p.getUniqueId(), dir, placeholders);
+	}
+
+	public static String getMessage(UUID playerId, String dir, Object... placeholders) {
+		String message = TranslatedMessages.getStringFromLang(TranslatedMessages.getLang(playerId), dir, placeholders);
 		return coloredBungeeMessage(message);
 	}
 

--- a/src/com/elikill58/negativity/bungee/NegativityListener.java
+++ b/src/com/elikill58/negativity/bungee/NegativityListener.java
@@ -18,7 +18,9 @@ import com.elikill58.negativity.universal.pluginMessages.AlertMessage;
 import com.elikill58.negativity.universal.pluginMessages.ClientModsListMessage;
 import com.elikill58.negativity.universal.pluginMessages.NegativityMessage;
 import com.elikill58.negativity.universal.pluginMessages.NegativityMessagesManager;
+import com.elikill58.negativity.universal.pluginMessages.ProxyExecuteBanMessage;
 import com.elikill58.negativity.universal.pluginMessages.ProxyPingMessage;
+import com.elikill58.negativity.universal.pluginMessages.ProxyRevokeBanMessage;
 import com.elikill58.negativity.universal.pluginMessages.ReportMessage;
 import com.elikill58.negativity.universal.utils.UniversalUtils;
 
@@ -112,6 +114,12 @@ public class NegativityListener implements Listener {
 			if (!hasPermitted) {
 				NegativityListener.report.add(new Report("/server " + player.getServer().getInfo().getName(), place));
 			}
+		} else if (message instanceof ProxyExecuteBanMessage) {
+			ProxyExecuteBanMessage banMessage = (ProxyExecuteBanMessage) message;
+			BanManager.executeBan(banMessage.getBan());
+		} else if (message instanceof ProxyRevokeBanMessage) {
+			ProxyRevokeBanMessage revocationMessage = (ProxyRevokeBanMessage) message;
+			BanManager.revokeBan(revocationMessage.getPlayerId());
 		} else {
 			BungeeNegativity.getInstance().getLogger().log(Level.WARNING, "Unhandled plugin message %s.", message.getClass());
 		}

--- a/src/com/elikill58/negativity/spigot/Messages.java
+++ b/src/com/elikill58/negativity/spigot/Messages.java
@@ -4,6 +4,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 import com.elikill58.negativity.spigot.utils.Utils;
+import com.elikill58.negativity.universal.NegativityAccount;
 import com.elikill58.negativity.universal.TranslatedMessages;
 
 public class Messages {
@@ -15,6 +16,11 @@ public class Messages {
 
 	public static String getMessage(Player p, String dir, Object... placeholders) {
 		String message = TranslatedMessages.getStringFromLang(TranslatedMessages.getLang(p.getUniqueId()), dir, placeholders);
+		return Utils.coloredMessage(message);
+	}
+
+	public static String getMessage(NegativityAccount account, String dir, Object... placeholders) {
+		String message = TranslatedMessages.getStringFromLang(account.getLang(), dir, placeholders);
 		return Utils.coloredMessage(message);
 	}
 

--- a/src/com/elikill58/negativity/spigot/SpigotNegativity.java
+++ b/src/com/elikill58/negativity/spigot/SpigotNegativity.java
@@ -68,6 +68,7 @@ import com.elikill58.negativity.universal.adapter.Adapter;
 import com.elikill58.negativity.universal.adapter.SpigotAdapter;
 import com.elikill58.negativity.universal.ban.BanManager;
 import com.elikill58.negativity.universal.ban.BanUtils;
+import com.elikill58.negativity.universal.ban.processor.ForwardToProxyBanProcessor;
 import com.elikill58.negativity.universal.ban.support.AdvancedBanProcessor;
 import com.elikill58.negativity.universal.ban.support.BukkitBanProcessor;
 import com.elikill58.negativity.universal.ban.support.MaxBansProcessor;
@@ -178,6 +179,14 @@ public class SpigotNegativity extends JavaPlugin {
 
 		StringJoiner supportedPluginName = new StringJoiner(", ");
 		BanManager.registerProcessor("bukkit", new BukkitBanProcessor());
+		BanManager.registerProcessor(ForwardToProxyBanProcessor.PROCESSOR_ID, new ForwardToProxyBanProcessor(rawMessage -> {
+			Player player = Utils.getFirstOnlinePlayer();
+			if (player != null) {
+				player.sendPluginMessage(this, NegativityMessagesManager.CHANNEL_ID, rawMessage);
+			} else {
+				getLogger().severe("Could not send ban revocation request to proxy because there are no player online.");
+			}
+		}));
 		if (Bukkit.getPluginManager().getPlugin("Essentials") != null) {
 			essentialsSupport = true;
 			supportedPluginName.add("Essentials");

--- a/src/com/elikill58/negativity/spigot/utils/Utils.java
+++ b/src/com/elikill58/negativity/spigot/utils/Utils.java
@@ -22,6 +22,7 @@ import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import com.elikill58.negativity.spigot.ClickableText;
 import com.elikill58.negativity.spigot.SpigotNegativity;
@@ -110,6 +111,12 @@ public class Utils {
 			e.printStackTrace();
 		}
 		return list;
+	}
+
+	@Nullable
+	public static Player getFirstOnlinePlayer() {
+		List<Player> onlinePlayers = getOnlinePlayers();
+		return onlinePlayers.isEmpty() ? null : onlinePlayers.iterator().next();
 	}
 
 	public static ItemStack createSkull(String name, int amount, String owner, String... lore) {

--- a/src/com/elikill58/negativity/sponge/SpongeNegativity.java
+++ b/src/com/elikill58/negativity/sponge/SpongeNegativity.java
@@ -285,10 +285,8 @@ public class SpongeNegativity {
 	}
 
 	@Listener
-	public void onLogin(ClientConnectionEvent.Login e) {
-		UUID playerId = e.getTargetUser().getUniqueId();
-		SpongeNegativityPlayer.removeFromCache(playerId);
-
+	public void onAuth(ClientConnectionEvent.Auth e) {
+		UUID playerId = e.getProfile().getUniqueId();
 		Ban activeBan = BanManager.getActiveBan(playerId);
 		if (activeBan != null) {
 			NegativityAccount account = Adapter.getAdapter().getNegativityAccount(playerId);
@@ -311,6 +309,7 @@ public class SpongeNegativity {
 	public void onJoin(ClientConnectionEvent.Join e, @First Player p) {
 		if (UniversalUtils.isMe(p.getUniqueId()))
 			p.sendMessage(Text.builder("Ce serveur utilise Negativity ! Waw :')").color(TextColors.GREEN).build());
+		SpongeNegativityPlayer.removeFromCache(p.getUniqueId());
 		SpongeNegativityPlayer np = SpongeNegativityPlayer.getNegativityPlayer(p);
 		np.TIME_INVINCIBILITY = System.currentTimeMillis() + 8000;
 		Task.builder().delayTicks(20).execute(new Runnable() {

--- a/src/com/elikill58/negativity/sponge/SpongeNegativity.java
+++ b/src/com/elikill58/negativity/sponge/SpongeNegativity.java
@@ -88,6 +88,7 @@ import com.elikill58.negativity.universal.adapter.SpongeAdapter;
 import com.elikill58.negativity.universal.ban.Ban;
 import com.elikill58.negativity.universal.ban.BanManager;
 import com.elikill58.negativity.universal.ban.BanUtils;
+import com.elikill58.negativity.universal.ban.processor.ForwardToProxyBanProcessor;
 import com.elikill58.negativity.universal.ban.processor.SpongeBanProcessor;
 import com.elikill58.negativity.universal.permissions.Perm;
 import com.elikill58.negativity.universal.pluginMessages.AlertMessage;
@@ -155,6 +156,14 @@ public class SpongeNegativity {
 		plugin.getLogger().info("Negativity v" + plugin.getVersion().get() + " loaded.");
 
 		BanManager.registerProcessor("sponge", new SpongeBanProcessor());
+		BanManager.registerProcessor(ForwardToProxyBanProcessor.PROCESSOR_ID, new ForwardToProxyBanProcessor(rawMessage -> {
+			Player player = Utils.getFirstOnlinePlayer();
+			if (player != null) {
+				channel.sendTo(player, payload -> payload.writeBytes(rawMessage));
+			} else {
+				logger.error("Could not send ban revocation request to proxy because there are no player online.");
+			}
+		}));
 		Perm.registerChecker(Perm.PLATFORM_CHECKER, new SpongePermissionChecker());
 
 		if(SpongeUpdateChecker.ifUpdateAvailable()) {

--- a/src/com/elikill58/negativity/sponge/utils/Utils.java
+++ b/src/com/elikill58/negativity/sponge/utils/Utils.java
@@ -49,6 +49,12 @@ public class Utils {
 	}
 
 	@Nullable
+	public static Player getFirstOnlinePlayer() {
+		Collection<Player> onlinePlayers = Sponge.getServer().getOnlinePlayers();
+		return onlinePlayers.isEmpty() ? null : onlinePlayers.iterator().next();
+	}
+
+	@Nullable
 	public static Player getRandomPlayer() {
 		Collection<Player> onlinePlayers = Sponge.getServer().getOnlinePlayers();
 		if (onlinePlayers.isEmpty())

--- a/src/com/elikill58/negativity/universal/ban/processor/ForwardToProxyBanProcessor.java
+++ b/src/com/elikill58/negativity/universal/ban/processor/ForwardToProxyBanProcessor.java
@@ -1,0 +1,66 @@
+package com.elikill58.negativity.universal.ban.processor;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import javax.annotation.Nullable;
+
+import com.elikill58.negativity.universal.adapter.Adapter;
+import com.elikill58.negativity.universal.ban.Ban;
+import com.elikill58.negativity.universal.ban.BanStatus;
+import com.elikill58.negativity.universal.ban.BanType;
+import com.elikill58.negativity.universal.pluginMessages.NegativityMessagesManager;
+import com.elikill58.negativity.universal.pluginMessages.ProxyExecuteBanMessage;
+import com.elikill58.negativity.universal.pluginMessages.ProxyRevokeBanMessage;
+
+public class ForwardToProxyBanProcessor implements BanProcessor {
+
+	public static final String PROCESSOR_ID = "proxy";
+
+	private final Consumer<byte[]> pluginMessageSender;
+
+	public ForwardToProxyBanProcessor(Consumer<byte[]> pluginMessageSender) {
+		this.pluginMessageSender = pluginMessageSender;
+	}
+
+	@Nullable
+	@Override
+	public Ban executeBan(Ban ban) {
+		try {
+			byte[] rawMessage = NegativityMessagesManager.writeMessage(new ProxyExecuteBanMessage(ban));
+			pluginMessageSender.accept(rawMessage);
+		} catch (IOException e) {
+			Adapter.getAdapter().error("Could not write ProxyBanMessage: " + e.getMessage());
+			e.printStackTrace();
+		}
+		return ban;
+	}
+
+	@Nullable
+	@Override
+	public Ban revokeBan(UUID playerId) {
+		try {
+			byte[] rawMessage = NegativityMessagesManager.writeMessage(new ProxyRevokeBanMessage(playerId));
+			pluginMessageSender.accept(rawMessage);
+		} catch (IOException e) {
+			Adapter.getAdapter().error("Could not write ProxyBanMessage: " + e.getMessage());
+			e.printStackTrace();
+		}
+		return new Ban(playerId, "", "", BanType.UNKNOW, -1, null, BanStatus.REVOKED);
+	}
+
+	@Nullable
+	@Override
+	public Ban getActiveBan(UUID playerId) {
+		// If this processor is active, companion plugins on the proxies are supposed to handle bans
+		return null;
+	}
+
+	@Override
+	public List<Ban> getLoggedBans(UUID playerId) {
+		return Collections.emptyList();
+	}
+}

--- a/src/com/elikill58/negativity/universal/pluginMessages/NegativityMessagesManager.java
+++ b/src/com/elikill58/negativity/universal/pluginMessages/NegativityMessagesManager.java
@@ -25,6 +25,8 @@ public class NegativityMessagesManager {
 		messages.put(ProxyPingMessage.MESSAGE_ID, ProxyPingMessage::new);
 		messages.put(ReportMessage.MESSAGE_ID, ReportMessage::new);
 		messages.put(ClientModsListMessage.MESSAGE_ID, ClientModsListMessage::new);
+		messages.put(ProxyExecuteBanMessage.MESSAGE_ID, ProxyExecuteBanMessage::new);
+		messages.put(ProxyRevokeBanMessage.MESSAGE_ID, ProxyRevokeBanMessage::new);
 		MESSAGES_BY_ID = Collections.unmodifiableMap(messages);
 	}
 

--- a/src/com/elikill58/negativity/universal/pluginMessages/ProxyExecuteBanMessage.java
+++ b/src/com/elikill58/negativity/universal/pluginMessages/ProxyExecuteBanMessage.java
@@ -1,0 +1,63 @@
+package com.elikill58.negativity.universal.pluginMessages;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.UUID;
+
+import com.elikill58.negativity.universal.ban.Ban;
+import com.elikill58.negativity.universal.ban.BanStatus;
+import com.elikill58.negativity.universal.ban.BanType;
+
+public class ProxyExecuteBanMessage implements NegativityMessage {
+
+	public static final byte MESSAGE_ID = 4;
+
+	private Ban ban;
+
+	public ProxyExecuteBanMessage() {
+	}
+
+	public ProxyExecuteBanMessage(Ban ban) {
+		this.ban = ban;
+	}
+
+	@Override
+	public void readFrom(DataInputStream input) throws IOException {
+		this.ban = new Ban(
+				new UUID(input.readLong(), input.readLong()),
+				input.readUTF(),
+				input.readUTF(),
+				BanType.valueOf(input.readUTF()),
+				input.readLong(),
+				input.readBoolean() ? input.readUTF() : null,
+				BanStatus.valueOf(input.readUTF())
+		);
+	}
+
+	@Override
+	public void writeTo(DataOutputStream output) throws IOException {
+		output.writeLong(ban.getPlayerId().getMostSignificantBits());
+		output.writeLong(ban.getPlayerId().getLeastSignificantBits());
+		output.writeUTF(ban.getReason());
+		output.writeUTF(ban.getBannedBy());
+		output.writeUTF(ban.getBanType().name());
+		output.writeLong(ban.getExpirationTime());
+		if (ban.getCheatName() != null) {
+			output.writeBoolean(true);
+			output.writeUTF(ban.getCheatName());
+		} else {
+			output.writeBoolean(false);
+		}
+		output.writeUTF(ban.getStatus().name());
+	}
+
+	@Override
+	public byte messageId() {
+		return MESSAGE_ID;
+	}
+
+	public Ban getBan() {
+		return ban;
+	}
+}

--- a/src/com/elikill58/negativity/universal/pluginMessages/ProxyRevokeBanMessage.java
+++ b/src/com/elikill58/negativity/universal/pluginMessages/ProxyRevokeBanMessage.java
@@ -1,0 +1,40 @@
+package com.elikill58.negativity.universal.pluginMessages;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.UUID;
+
+public class ProxyRevokeBanMessage implements NegativityMessage {
+
+	public static final byte MESSAGE_ID = 5;
+
+	private UUID playerId;
+
+	public ProxyRevokeBanMessage() {
+	}
+
+	public ProxyRevokeBanMessage(UUID playerId) {
+		this.playerId = playerId;
+	}
+
+	@Override
+	public void readFrom(DataInputStream input) throws IOException {
+		this.playerId = new UUID(input.readLong(), input.readLong());
+	}
+
+	@Override
+	public void writeTo(DataOutputStream output) throws IOException {
+		output.writeLong(playerId.getMostSignificantBits());
+		output.writeLong(playerId.getLeastSignificantBits());
+	}
+
+	@Override
+	public byte messageId() {
+		return MESSAGE_ID;
+	}
+
+	public UUID getPlayerId() {
+		return playerId;
+	}
+}

--- a/src/com/elikill58/negativity/velocity/NegativityListener.java
+++ b/src/com/elikill58/negativity/velocity/NegativityListener.java
@@ -20,7 +20,9 @@ import com.elikill58.negativity.universal.pluginMessages.AlertMessage;
 import com.elikill58.negativity.universal.pluginMessages.ClientModsListMessage;
 import com.elikill58.negativity.universal.pluginMessages.NegativityMessage;
 import com.elikill58.negativity.universal.pluginMessages.NegativityMessagesManager;
+import com.elikill58.negativity.universal.pluginMessages.ProxyExecuteBanMessage;
 import com.elikill58.negativity.universal.pluginMessages.ProxyPingMessage;
+import com.elikill58.negativity.universal.pluginMessages.ProxyRevokeBanMessage;
 import com.elikill58.negativity.universal.pluginMessages.ReportMessage;
 import com.elikill58.negativity.universal.utils.UniversalUtils;
 import com.velocitypowered.api.event.ResultedEvent;
@@ -123,6 +125,12 @@ public class NegativityListener {
 			if (!hasPermitted) {
 				NegativityListener.report.add(new Report("/server " + p.getCurrentServer().get().getServerInfo().getName(), place));
 			}
+		} else if (message instanceof ProxyExecuteBanMessage) {
+			ProxyExecuteBanMessage banMessage = (ProxyExecuteBanMessage) message;
+			BanManager.executeBan(banMessage.getBan());
+		} else if (message instanceof ProxyRevokeBanMessage) {
+			ProxyRevokeBanMessage revocationMessage = (ProxyRevokeBanMessage) message;
+			BanManager.revokeBan(revocationMessage.getPlayerId());
 		} else {
 			VelocityNegativity.getInstance().getLogger().warn("Unhandled plugin message: {}.", message.getClass().getName());
 		}


### PR DESCRIPTION
Fixes #120 by using a `commands` processor on the proxy
Fixes #126

[Preview of the documentation changes](https://github.com/RedNesto/NegativityWiki/compare/proxy-ban-processor)