### PR TITLE
Add some time data to NegativityAccount and bans

### DIFF
--- a/src/com/elikill58/negativity/spigot/commands/BanCommand.java
+++ b/src/com/elikill58/negativity/spigot/commands/BanCommand.java
@@ -17,7 +17,6 @@ import com.elikill58.negativity.spigot.utils.Utils;
 import com.elikill58.negativity.universal.Cheat;
 import com.elikill58.negativity.universal.ban.Ban;
 import com.elikill58.negativity.universal.ban.BanManager;
-import com.elikill58.negativity.universal.ban.BanStatus;
 import com.elikill58.negativity.universal.ban.BanType;
 import com.elikill58.negativity.universal.utils.UniversalUtils;
 
@@ -66,7 +65,7 @@ public class BanCommand implements CommandExecutor, TabCompleter {
 		}
 
 		String reason = reasonJoiner.toString();
-		BanManager.executeBan(new Ban(target.getUniqueId(), reason, sender.getName(), BanType.MOD, time, cheatName, BanStatus.ACTIVE));
+		BanManager.executeBan(Ban.active(target.getUniqueId(), reason, sender.getName(), BanType.MOD, time, cheatName));
 		if (!sender.equals(target))
 			Messages.sendMessage(sender, "ban.well_ban", "%name%", target.getName(), "%reason%", reason);
 		return false;

--- a/src/com/elikill58/negativity/sponge/commands/BanCommand.java
+++ b/src/com/elikill58/negativity/sponge/commands/BanCommand.java
@@ -21,7 +21,6 @@ import com.elikill58.negativity.sponge.utils.NegativityCmdWrapper;
 import com.elikill58.negativity.universal.Cheat;
 import com.elikill58.negativity.universal.ban.Ban;
 import com.elikill58.negativity.universal.ban.BanManager;
-import com.elikill58.negativity.universal.ban.BanStatus;
 import com.elikill58.negativity.universal.ban.BanType;
 import com.elikill58.negativity.universal.permissions.Perm;
 import com.elikill58.negativity.universal.utils.UniversalUtils;
@@ -48,7 +47,7 @@ public class BanCommand implements CommandExecutor {
 		String reason = args.requireOne("reason");
 
 		BanType banType = src instanceof Player ? BanType.MOD : BanType.CONSOLE;
-		BanManager.executeBan(new Ban(targetPlayer.getUniqueId(), reason, src.getName(), banType, expiration, getFromReason(reason), BanStatus.ACTIVE));
+		BanManager.executeBan(Ban.active(targetPlayer.getUniqueId(), reason, src.getName(), banType, expiration, getFromReason(reason)));
 
 		Messages.sendMessage(src, "ban.well_ban", "%name%", targetPlayer.getName(), "%reason%", reason);
 		return CommandResult.success();

--- a/src/com/elikill58/negativity/universal/NegativityAccount.java
+++ b/src/com/elikill58/negativity/universal/NegativityAccount.java
@@ -19,18 +19,20 @@ public final class NegativityAccount {
 	private final Minerate minerate;
 	private int mostClicksPerSecond;
 	private final Map<String, Integer> warns;
+	private final long creationTime;
 
 	public NegativityAccount(UUID playerId) {
-		this(playerId, null, TranslatedMessages.getDefaultLang(), new Minerate(), 0, new HashMap<>());
+		this(playerId, null, TranslatedMessages.getDefaultLang(), new Minerate(), 0, new HashMap<>(), System.currentTimeMillis());
 	}
 
-	public NegativityAccount(UUID playerId, String playerName, String lang, Minerate minerate, int mostClicksPerSecond, Map<String, Integer> warns) {
+	public NegativityAccount(UUID playerId, String playerName, String lang, Minerate minerate, int mostClicksPerSecond, Map<String, Integer> warns, long creationTime) {
 		this.playerId = playerId;
 		this.playerName = playerName;
 		this.lang = lang;
 		this.minerate = minerate;
 		this.mostClicksPerSecond = mostClicksPerSecond;
 		this.warns = warns;
+		this.creationTime = creationTime;
 	}
 
 	public UUID getPlayerId() {
@@ -88,5 +90,9 @@ public final class NegativityAccount {
 	@NonNull
 	public static NegativityAccount get(UUID accountId) {
 		return Adapter.getAdapter().getAccountManager().getNow(accountId);
+	}
+
+	public long getCreationTime() {
+		return creationTime;
 	}
 }

--- a/src/com/elikill58/negativity/universal/ban/Ban.java
+++ b/src/com/elikill58/negativity/universal/ban/Ban.java
@@ -15,8 +15,39 @@ public final class Ban {
 	@Nullable
 	private final String cheatName;
 	private final BanStatus status;
+	private final long executionTime;
+	private final long revocationTime;
 
-	public Ban(UUID playerId, String reason, String bannedBy, BanType banType, long expirationTime, @Nullable String cheatName, BanStatus status) {
+	public Ban(UUID playerId,
+			   String reason,
+			   String bannedBy,
+			   BanType banType,
+			   long expirationTime,
+			   @Nullable String cheatName,
+			   BanStatus status) {
+		this(playerId, reason, bannedBy, banType, expirationTime, cheatName, status, -1);
+	}
+
+	public Ban(UUID playerId,
+			   String reason,
+			   String bannedBy,
+			   BanType banType,
+			   long expirationTime,
+			   @Nullable String cheatName,
+			   BanStatus status,
+			   long executionTime) {
+		this(playerId, reason, bannedBy, banType, expirationTime, cheatName, status, executionTime, -1);
+	}
+
+	public Ban(UUID playerId,
+			   String reason,
+			   String bannedBy,
+			   BanType banType,
+			   long expirationTime,
+			   @Nullable String cheatName,
+			   BanStatus status,
+			   long executionTime,
+			   long revocationTime) {
 		this.playerId = playerId;
 		this.reason = reason;
 		this.bannedBy = bannedBy;
@@ -24,6 +55,8 @@ public final class Ban {
 		this.expirationTime = expirationTime;
 		this.cheatName = cheatName;
 		this.status = status;
+		this.executionTime = executionTime;
+		this.revocationTime = revocationTime;
 	}
 
 	public UUID getPlayerId() {
@@ -59,6 +92,14 @@ public final class Ban {
 		return status;
 	}
 
+	public long getExecutionTime() {
+		return executionTime;
+	}
+
+	public long getRevocationTime() {
+		return revocationTime;
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;
@@ -70,15 +111,53 @@ public final class Ban {
 				bannedBy.equals(ban.bannedBy) &&
 				banType == ban.banType &&
 				Objects.equals(cheatName, ban.cheatName) &&
-				status == ban.status;
+				status == ban.status &&
+				executionTime == ban.executionTime &&
+				revocationTime == ban.revocationTime;
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(playerId, reason, bannedBy, banType, expirationTime, cheatName, status);
+		return Objects.hash(playerId, reason, bannedBy, banType, expirationTime, cheatName, status, executionTime, revocationTime);
 	}
 
 	public static Ban from(Ban from, BanStatus status) {
-		return new Ban(from.getPlayerId(), from.getReason(), from.getBannedBy(), from.getBanType(), from.getExpirationTime(), from.getCheatName(), status);
+		return new Ban(from.getPlayerId(),
+				from.getReason(),
+				from.getBannedBy(),
+				from.getBanType(),
+				from.getExpirationTime(),
+				from.getCheatName(),
+				status,
+				from.getExecutionTime(),
+				from.getRevocationTime());
+	}
+
+	public static Ban activeFrom(Ban from) {
+		return new Ban(from.getPlayerId(),
+				from.getReason(),
+				from.getBannedBy(),
+				from.getBanType(),
+				from.getExpirationTime(),
+				from.getCheatName(),
+				BanStatus.ACTIVE,
+				from.getExecutionTime(),
+				-1);
+	}
+
+	public static Ban revokedFrom(Ban from, long revocationTime) {
+		return new Ban(from.getPlayerId(),
+				from.getReason(),
+				from.getBannedBy(),
+				from.getBanType(),
+				from.getExpirationTime(),
+				from.getCheatName(),
+				BanStatus.REVOKED,
+				from.getExecutionTime(),
+				revocationTime);
+	}
+
+	public static Ban active(UUID playerId, String reason, String bannedBy, BanType banType, long expirationTime, @Nullable String cheatName) {
+		return new Ban(playerId, reason, bannedBy, banType, expirationTime, cheatName, BanStatus.ACTIVE, System.currentTimeMillis());
 	}
 }

--- a/src/com/elikill58/negativity/universal/ban/BanUtils.java
+++ b/src/com/elikill58/negativity/universal/ban/BanUtils.java
@@ -54,7 +54,7 @@ public class BanUtils {
 		if (!isDefinitive) {
 			banDuration = System.currentTimeMillis() + BanUtils.computeBanDuration(player, reliability, cheat);
 		}
-		return BanManager.executeBan(new Ban(player.getUUID(), "Cheat (" + reason + ")", "Negativity", BanType.MOD, banDuration, reason, BanStatus.ACTIVE));
+		return BanManager.executeBan(Ban.active(player.getUUID(), "Cheat (" + reason + ")", "Negativity", BanType.MOD, banDuration, reason));
 	}
 
 	public static void kickForBan(NegativityPlayer player, Ban ban) {

--- a/src/com/elikill58/negativity/universal/ban/BansMigration.java
+++ b/src/com/elikill58/negativity/universal/ban/BansMigration.java
@@ -62,7 +62,7 @@ public class BansMigration {
 						// We remove the active ban and all the following ones from the list of bans to keep in logs
 						loggedBansToSave = loadedBans.subList(0, loadedBans.indexOf(extractedActiveBan));
 
-						Ban activeBan = Ban.from(extractedActiveBan, BanStatus.ACTIVE);
+						Ban activeBan = Ban.activeFrom(extractedActiveBan);
 						activeBanStorage.save(activeBan);
 					}
 

--- a/src/com/elikill58/negativity/universal/ban/processor/BaseNegativityBanProcessor.java
+++ b/src/com/elikill58/negativity/universal/ban/processor/BaseNegativityBanProcessor.java
@@ -48,7 +48,7 @@ public class BaseNegativityBanProcessor implements BanProcessor {
 			return null;
 
 		activeBanStorage.remove(playerId);
-		Ban revokedLoggedBan = Ban.from(activeBan, BanStatus.REVOKED);
+		Ban revokedLoggedBan = Ban.revokedFrom(activeBan, System.currentTimeMillis());
 
 		if (banLogsStorage != null) {
 			banLogsStorage.save(revokedLoggedBan);

--- a/src/com/elikill58/negativity/universal/ban/processor/CommandBanProcessor.java
+++ b/src/com/elikill58/negativity/universal/ban/processor/CommandBanProcessor.java
@@ -35,7 +35,7 @@ public class CommandBanProcessor implements BanProcessor {
 	public Ban revokeBan(UUID playerId) {
 		Adapter adapter = Adapter.getAdapter();
 		unbanCommands.forEach(cmd -> adapter.runConsoleCommand(applyPlaceholders(cmd, playerId, "Unknown")));
-		return new Ban(playerId, "Unknown", "Unknown", BanType.UNKNOW, 0, null, BanStatus.REVOKED);
+		return new Ban(playerId, "Unknown", "Unknown", BanType.UNKNOW, 0, null, BanStatus.REVOKED, -1, System.currentTimeMillis());
 	}
 
 	@Nullable

--- a/src/com/elikill58/negativity/universal/ban/processor/ForwardToProxyBanProcessor.java
+++ b/src/com/elikill58/negativity/universal/ban/processor/ForwardToProxyBanProcessor.java
@@ -49,7 +49,7 @@ public class ForwardToProxyBanProcessor implements BanProcessor {
 			Adapter.getAdapter().error("Could not write ProxyBanMessage: " + e.getMessage());
 			e.printStackTrace();
 		}
-		return new Ban(playerId, "", "", BanType.UNKNOW, -1, null, BanStatus.REVOKED);
+		return new Ban(playerId, "", "", BanType.UNKNOW, -1, null, BanStatus.REVOKED, -1, System.currentTimeMillis());
 	}
 
 	@Nullable

--- a/src/com/elikill58/negativity/universal/ban/processor/SpongeBanProcessor.java
+++ b/src/com/elikill58/negativity/universal/ban/processor/SpongeBanProcessor.java
@@ -67,7 +67,8 @@ public class SpongeBanProcessor implements BanProcessor {
 		String reason = revokedBan.getReason().map(TextSerializers.FORMATTING_CODE::serialize).orElse("");
 		String bannedBy = revokedBan.getBanSource().map(TextSerializers.FORMATTING_CODE::serialize).orElse("");
 		long expirationTime = revokedBan.getExpirationDate().map(Instant::toEpochMilli).orElse(-1L);
-		return new Ban(playerId, reason, bannedBy, BanType.UNKNOW, expirationTime, null, BanStatus.REVOKED);
+		long executionTime = revokedBan.getCreationDate().toEpochMilli();
+		return new Ban(playerId, reason, bannedBy, BanType.UNKNOW, expirationTime, null, BanStatus.REVOKED, executionTime, System.currentTimeMillis());
 	}
 
 	@Override
@@ -97,7 +98,8 @@ public class SpongeBanProcessor implements BanProcessor {
 		String reason = activeBan.getReason().map(TextSerializers.FORMATTING_CODE::serialize).orElse("");
 		String bannedBy = activeBan.getBanSource().map(TextSerializers.FORMATTING_CODE::serialize).orElse("");
 		long expirationTime = activeBan.getExpirationDate().map(Instant::toEpochMilli).orElse(-1L);
-		return new Ban(playerId, reason, bannedBy, BanType.UNKNOW, expirationTime, null, BanStatus.ACTIVE);
+		long executionTime = activeBan.getCreationDate().toEpochMilli();
+		return new Ban(playerId, reason, bannedBy, BanType.UNKNOW, expirationTime, null, BanStatus.ACTIVE, executionTime);
 	}
 
 	@Override

--- a/src/com/elikill58/negativity/universal/ban/storage/FileActiveBanStorage.java
+++ b/src/com/elikill58/negativity/universal/ban/storage/FileActiveBanStorage.java
@@ -108,7 +108,8 @@ public class FileActiveBanStorage implements ActiveBanStorage {
 				+ ":reason=" + ban.getReason().replaceAll(":", "")
 				+ ":bantype=" + ban.getBanType().name()
 				+ (ban.getCheatName() != null ? ":ac=" + ban.getCheatName() : "")
-				+ ":by=" + ban.getBannedBy();
+				+ ":by=" + ban.getBannedBy()
+				+ ":executiontime=" + ban.getExecutionTime();
 	}
 
 	@Nullable
@@ -131,6 +132,7 @@ public class FileActiveBanStorage implements ActiveBanStorage {
 		boolean def = false;
 		BanType banType = BanType.UNKNOW;
 		String ac = null;
+		long executionTime = -1;
 		for (String s : content) {
 			String[] part = s.split("=", 2);
 			if (part.length != 2)
@@ -157,6 +159,9 @@ public class FileActiveBanStorage implements ActiveBanStorage {
 				case "by":
 					by = value;
 					break;
+				case "executiontime":
+					executionTime = Long.parseLong(value);
+					break;
 				default:
 					Adapter.getAdapter().warn("Type " + type + " unknow. Value: " + value);
 					break;
@@ -167,6 +172,6 @@ public class FileActiveBanStorage implements ActiveBanStorage {
 			expirationTime = -1;
 		}
 
-		return new Ban(playerId, reason, by, banType, expirationTime, ac, BanStatus.ACTIVE);
+		return new Ban(playerId, reason, by, banType, expirationTime, ac, BanStatus.ACTIVE, executionTime);
 	}
 }

--- a/src/com/elikill58/negativity/universal/ban/storage/FileBanLogsStorage.java
+++ b/src/com/elikill58/negativity/universal/ban/storage/FileBanLogsStorage.java
@@ -69,7 +69,9 @@ public class FileBanLogsStorage implements BanLogsStorage {
 				+ ":bantype=" + ban.getBanType().name()
 				+ (ban.getCheatName() != null ? ":ac=" + ban.getCheatName() : "")
 				+ ":by=" + ban.getBannedBy()
-				+ ":revoked=" + ban.getStatus().equals(BanStatus.REVOKED);
+				+ ":revoked=" + ban.getStatus().equals(BanStatus.REVOKED)
+				+ ":executiontime=" + ban.getExecutionTime()
+				+ ":revocationtime=" + ban.getRevocationTime();
 	}
 
 	@Nullable
@@ -91,6 +93,8 @@ public class FileBanLogsStorage implements BanLogsStorage {
 		BanStatus isRevoked = BanStatus.EXPIRED;
 		BanType banType = BanType.UNKNOW;
 		String ac = null;
+		long executionTime = -1;
+		long revocationTime = -1;
 		for (String s : content) {
 			String[] part = s.split("=", 2);
 			if (part.length != 2)
@@ -118,12 +122,18 @@ public class FileBanLogsStorage implements BanLogsStorage {
 				case "revoked":
 					isRevoked = BanStatus.REVOKED;
 					break;
+				case "executiontime":
+					executionTime = Long.parseLong(value);
+					break;
+				case "revocationtime":
+					revocationTime = Long.parseLong(value);
+					break;
 				default:
 					Adapter.getAdapter().warn("Type " + type + " unknow. Value: " + value);
 					break;
 			}
 		}
 
-		return new Ban(playerId, reason, by, banType, expirationTime, ac, isRevoked);
+		return new Ban(playerId, reason, by, banType, expirationTime, ac, isRevoked, executionTime, revocationTime);
 	}
 }

--- a/src/com/elikill58/negativity/universal/ban/support/AdvancedBanProcessor.java
+++ b/src/com/elikill58/negativity/universal/ban/support/AdvancedBanProcessor.java
@@ -71,7 +71,8 @@ public class AdvancedBanProcessor implements BanProcessor {
 				BanType.UNKNOW,
 				punishment.getEnd(),
 				punishment.getReason(),
-				BanStatus.ACTIVE);
+				BanStatus.ACTIVE,
+				punishment.getStart());
 	}
 
 	@Override
@@ -89,6 +90,8 @@ public class AdvancedBanProcessor implements BanProcessor {
 				BanType.UNKNOW,
 				punishment.getEnd(),
 				punishment.getReason(),
-				status);
+				status,
+				punishment.getStart(),
+				punishment.isExpired() ? -1 : System.currentTimeMillis());
 	}
 }

--- a/src/com/elikill58/negativity/universal/ban/support/BukkitBanProcessor.java
+++ b/src/com/elikill58/negativity/universal/ban/support/BukkitBanProcessor.java
@@ -79,7 +79,8 @@ public class BukkitBanProcessor implements BanProcessor {
 			reason = "";
 		}
 
-		return new Ban(playerId, reason, banEntry.getSource(), BanType.UNKNOW, expirationTime, reason, BanStatus.ACTIVE);
+		long executionTime = banEntry.getCreated().getTime();
+		return new Ban(playerId, reason, banEntry.getSource(), BanType.UNKNOW, expirationTime, reason, BanStatus.ACTIVE, executionTime);
 	}
 
 	@Override
@@ -102,6 +103,9 @@ public class BukkitBanProcessor implements BanProcessor {
 			reason = "";
 		}
 
-		return new Ban(playerId, reason, banEntry.getSource(), BanType.UNKNOW, expirationTime, reason, revoked ? BanStatus.REVOKED : BanStatus.EXPIRED);
+		BanStatus status = revoked ? BanStatus.REVOKED : BanStatus.EXPIRED;
+		long executionTime = banEntry.getCreated().getTime();
+		long revocationTime = revoked ? System.currentTimeMillis() : -1;
+		return new Ban(playerId, reason, banEntry.getSource(), BanType.UNKNOW, expirationTime, reason, status, executionTime, revocationTime);
 	}
 }

--- a/src/com/elikill58/negativity/universal/ban/support/MaxBansProcessor.java
+++ b/src/com/elikill58/negativity/universal/ban/support/MaxBansProcessor.java
@@ -54,7 +54,8 @@ public class MaxBansProcessor implements BanProcessor {
 		if (revokedBan instanceof Temporary) {
 			expirationTime = ((Temporary) revokedBan).getExpires();
 		}
-		return new Ban(playerId, revokedBan.getReason(), revokedBan.getBanner(), BanType.UNKNOW, expirationTime, revokedBan.getReason(), BanStatus.REVOKED);
+		long revocationTime = System.currentTimeMillis();
+		return new Ban(playerId, revokedBan.getReason(), revokedBan.getBanner(), BanType.UNKNOW, expirationTime, revokedBan.getReason(), BanStatus.REVOKED, revokedBan.getCreated(), revocationTime);
 	}
 
 	@Nullable
@@ -72,7 +73,7 @@ public class MaxBansProcessor implements BanProcessor {
 			expirationTime = ((Temporary) ban).getExpires();
 		}
 
-		return new Ban(playerId, ban.getReason(), ban.getBanner(), BanType.UNKNOW, expirationTime, ban.getReason(), BanStatus.EXPIRED);
+		return new Ban(playerId, ban.getReason(), ban.getBanner(), BanType.UNKNOW, expirationTime, ban.getReason(), BanStatus.ACTIVE, ban.getCreated());
 	}
 
 	@Override
@@ -84,7 +85,7 @@ public class MaxBansProcessor implements BanProcessor {
 
 		List<Ban> loggedBans = new ArrayList<>();
 		for (HistoryRecord record : MaxBans.instance.getBanManager().getHistory(player.getName())) {
-			loggedBans.add(new Ban(playerId, record.getMessage(), record.getBanner(), BanType.UNKNOW, 0, record.getMessage(), BanStatus.EXPIRED));
+			loggedBans.add(new Ban(playerId, record.getMessage(), record.getBanner(), BanType.UNKNOW, 0, record.getMessage(), BanStatus.EXPIRED, record.getCreated()));
 		}
 		return loggedBans;
 	}

--- a/src/com/elikill58/negativity/universal/dataStorage/file/SpigotFileNegativityAccountStorage.java
+++ b/src/com/elikill58/negativity/universal/dataStorage/file/SpigotFileNegativityAccountStorage.java
@@ -9,7 +9,6 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 
-
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -40,7 +39,8 @@ public class SpigotFileNegativityAccountStorage extends NegativityAccountStorage
 		Minerate minerate = deserializeMinerate(config.getInt("minerate-full-mined"), config.getConfigurationSection("minerate"));
 		int mostClicksPerSecond = config.getInt("better-click");
 		Map<String, Integer> warns = deserializeViolations(config.getConfigurationSection("cheats"));
-		return CompletableFuture.completedFuture(new NegativityAccount(playerId, playerName, language, minerate, mostClicksPerSecond, warns));
+		long creationTime = config.getLong("creation-time", System.currentTimeMillis());
+		return CompletableFuture.completedFuture(new NegativityAccount(playerId, playerName, language, minerate, mostClicksPerSecond, warns, creationTime));
 	}
 
 	@Override
@@ -53,6 +53,7 @@ public class SpigotFileNegativityAccountStorage extends NegativityAccountStorage
 		serializeMinerate(account.getMinerate(), accountConfig.createSection("minerate"));
 		accountConfig.set("better-click", account.getMostClicksPerSecond());
 		serializeViolations(account, accountConfig.createSection("cheats"));
+		accountConfig.set("creation-time", account.getCreationTime());
 		try {
 			accountConfig.save(file);
 		} catch (IOException e) {

--- a/src/com/elikill58/negativity/universal/dataStorage/file/SpongeFileNegativityAccountStorage.java
+++ b/src/com/elikill58/negativity/universal/dataStorage/file/SpongeFileNegativityAccountStorage.java
@@ -43,7 +43,8 @@ public class SpongeFileNegativityAccountStorage extends NegativityAccountStorage
 			Minerate minerate = deserializeMinerate(node.getNode("minerate-full-mined").getInt(), node.getNode("minerate"));
 			int mostClicksPerSecond = node.getNode("better-click").getInt();
 			Map<String, Integer> warns = deserializeViolations(node.getNode("cheats"));
-			return CompletableFuture.completedFuture(new NegativityAccount(playerId, playerName, language, minerate, mostClicksPerSecond, warns));
+			long creationTime = node.getNode("creation-time").getLong(System.currentTimeMillis());
+			return CompletableFuture.completedFuture(new NegativityAccount(playerId, playerName, language, minerate, mostClicksPerSecond, warns, creationTime));
 		} catch (IOException e) {
 			SpongeNegativity.getInstance().getLogger().error("Could not load account {} to file", playerId, e);
 		}
@@ -63,6 +64,7 @@ public class SpongeFileNegativityAccountStorage extends NegativityAccountStorage
 			serializeMinerate(account.getMinerate(), accountNode.getNode("minerate"));
 			accountNode.getNode("better-click").setValue(account.getMostClicksPerSecond());
 			serializeViolations(account, accountNode.getNode("cheats"));
+			accountNode.getNode("creation-time", account.getCreationTime());
 			loader.save(accountNode);
 		} catch (IOException e) {
 			SpongeNegativity.getInstance().getLogger().error("Could not save account {} to file", account.getPlayerId(), e);

--- a/src/com/elikill58/negativity/universal/pluginMessages/AccountUpdateMessage.java
+++ b/src/com/elikill58/negativity/universal/pluginMessages/AccountUpdateMessage.java
@@ -48,7 +48,8 @@ public class AccountUpdateMessage implements NegativityMessage {
 			warns.put(input.readUTF(), input.readInt());
 		}
 
-		account = new NegativityAccount(playerId, playerName, language, minerate, mostClicksPerSecond, warns);
+		long creationTime = input.readLong();
+		account = new NegativityAccount(playerId, playerName, language, minerate, mostClicksPerSecond, warns, creationTime);
 	}
 
 	@Override
@@ -77,6 +78,8 @@ public class AccountUpdateMessage implements NegativityMessage {
 			output.writeUTF(warnEntry.getKey());
 			output.writeInt(warnEntry.getValue());
 		}
+
+		output.writeLong(account.getCreationTime());
 	}
 
 	@Override

--- a/src/com/elikill58/negativity/universal/pluginMessages/ProxyExecuteBanMessage.java
+++ b/src/com/elikill58/negativity/universal/pluginMessages/ProxyExecuteBanMessage.java
@@ -31,7 +31,9 @@ public class ProxyExecuteBanMessage implements NegativityMessage {
 				BanType.valueOf(input.readUTF()),
 				input.readLong(),
 				input.readBoolean() ? input.readUTF() : null,
-				BanStatus.valueOf(input.readUTF())
+				BanStatus.valueOf(input.readUTF()),
+				input.readLong(),
+				input.readLong()
 		);
 	}
 
@@ -50,6 +52,8 @@ public class ProxyExecuteBanMessage implements NegativityMessage {
 			output.writeBoolean(false);
 		}
 		output.writeUTF(ban.getStatus().name());
+		output.writeLong(ban.getExecutionTime());
+		output.writeLong(ban.getRevocationTime());
 	}
 
 	@Override

--- a/src/databaseMigrations/accounts/001-Add-Creation-Time-Column.sql
+++ b/src/databaseMigrations/accounts/001-Add-Creation-Time-Column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE negativity_accounts
+    ADD COLUMN creation_time TIMESTAMP NOT NULL DEFAULT NOW();

--- a/src/databaseMigrations/bans/active/001-Add-Execution-Time-Column.sql
+++ b/src/databaseMigrations/bans/active/001-Add-Execution-Time-Column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE negativity_bans_active
+    ADD COLUMN execution_time TIMESTAMP;

--- a/src/databaseMigrations/bans/logs/001-Add-Execution-Revocation-Time-Columns.sql
+++ b/src/databaseMigrations/bans/logs/001-Add-Execution-Revocation-Time-Columns.sql
@@ -1,0 +1,3 @@
+ALTER TABLE negativity_bans_log
+    ADD COLUMN execution_time TIMESTAMP,
+    ADD COLUMN revocation_time TIMESTAMP;


### PR DESCRIPTION
Useful for keeping records and moderation in general.

Existing bans won't be updated and will have NULL values, accounts creation time will be set to the time of the migration.