### PR TITLE
Update how file are saved

### DIFF
--- a/common/src/com/elikill58/negativity/api/NegativityPlayer.java
+++ b/common/src/com/elikill58/negativity/api/NegativityPlayer.java
@@ -383,6 +383,7 @@ public class NegativityPlayer implements FileSaverAction {
 	 */
 	public void logProof(String msg) {
 		proof.add(msg);
+		FileSaverTimer.getInstance().addAction(this);
 	}
 	
 	/**
@@ -416,6 +417,8 @@ public class NegativityPlayer implements FileSaverAction {
 	public FileHandle getOrCreateProofFileHandler() throws IOException {
 		if(proofFileHandler == null || proofFileHandler.isClosed()) {
 			File proofFile = new File(Adapter.getAdapter().getDataFolder().getAbsoluteFile(), "user" + File.pathSeparator + "proof" + File.pathSeparator + getUUID() + ".txt");
+			if(!proofFile.exists())
+				proofFile.createNewFile();
 			proofFileHandler = new FileHandle(proofFile);
 		}
 		return proofFileHandler;
@@ -423,8 +426,10 @@ public class NegativityPlayer implements FileSaverAction {
 	
 	@Override
 	public void save(FileSaverTimer timer) {
-		if (proof.isEmpty())
+		if (proof.isEmpty()) {
+	    	timer.removeActionRunning();
 			return;
+		}
 		
 		try {
 			getOrCreateProofFileHandler().write(proof);
@@ -432,7 +437,8 @@ public class NegativityPlayer implements FileSaverAction {
 		} catch (IOException e) {
 			e.printStackTrace();
 		}
-		
+
+    	timer.removeActionRunning();
 	}
 	
 	/**

--- a/common/src/com/elikill58/negativity/api/NegativityPlayer.java
+++ b/common/src/com/elikill58/negativity/api/NegativityPlayer.java
@@ -495,7 +495,8 @@ public class NegativityPlayer implements FileSaverAction {
 	 */
 	public void destroy() {
 		save(FileSaverTimer.getInstance());
-		proofFileHandler.close();
+		if(proofFileHandler != null && !proofFileHandler.isClosed())
+			proofFileHandler.close();
 		NegativityAccountManager accountManager = Adapter.getAdapter().getAccountManager();
 		accountManager.save(playerId).join();
 		accountManager.dispose(playerId);

--- a/common/src/com/elikill58/negativity/api/NegativityPlayer.java
+++ b/common/src/com/elikill58/negativity/api/NegativityPlayer.java
@@ -1,7 +1,8 @@
 package com.elikill58.negativity.api;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -148,7 +149,7 @@ public class NegativityPlayer implements FileSaverAction {
 	
 	/**
 	 * Check if the player have be detected for the given cheat
-	 * It also cehck for bypass and TPS drop
+	 * It also check for bypass and TPS drop
 	 * 
 	 * @param c the cheat which we are trying to detect
 	 * @return true if the player can be detected
@@ -394,17 +395,6 @@ public class NegativityPlayer implements FileSaverAction {
 			mustToBeSaved = false;
 			Adapter.getAdapter().getAccountManager().save(getUUID());
 		}
-		/*if (proof.isEmpty())
-			return;
-		try {
-			Path proofDir = Adapter.getAdapter().getDataFolder().getAbsoluteFile().toPath().resolve("user").resolve("proof");
-			Path proofFile = proofDir.resolve(getUUID() + ".txt");
-			Files.createDirectories(proofDir);
-			Files.write(proofFile, (String.join("\n", proof) + '\n').getBytes(), StandardOpenOption.CREATE, StandardOpenOption.APPEND);
-			proof.clear();
-		} catch (IOException e) {
-			e.printStackTrace();
-		}*/
 	}
 	
 	public void checkProofFileHandler() {
@@ -416,9 +406,9 @@ public class NegativityPlayer implements FileSaverAction {
 	
 	public FileHandle getOrCreateProofFileHandler() throws IOException {
 		if(proofFileHandler == null || proofFileHandler.isClosed()) {
-			File proofFile = new File(Adapter.getAdapter().getDataFolder().getAbsoluteFile(), "user" + File.separator + "proof" + File.separator + getUUID() + ".txt");
-			if(!proofFile.exists())
-				proofFile.createNewFile();
+			Path proofFile = Adapter.getAdapter().getDataFolder().toPath().resolve("user").resolve("proof").resolve(getUUID() + ".txt");
+			if(!Files.exists(proofFile))
+				Files.createFile(proofFile);
 			proofFileHandler = new FileHandle(proofFile);
 		}
 		return proofFileHandler;

--- a/common/src/com/elikill58/negativity/api/NegativityPlayer.java
+++ b/common/src/com/elikill58/negativity/api/NegativityPlayer.java
@@ -416,7 +416,7 @@ public class NegativityPlayer implements FileSaverAction {
 	
 	public FileHandle getOrCreateProofFileHandler() throws IOException {
 		if(proofFileHandler == null || proofFileHandler.isClosed()) {
-			File proofFile = new File(Adapter.getAdapter().getDataFolder().getAbsoluteFile(), "user" + File.pathSeparator + "proof" + File.pathSeparator + getUUID() + ".txt");
+			File proofFile = new File(Adapter.getAdapter().getDataFolder().getAbsoluteFile(), "user" + File.separator + "proof" + File.separator + getUUID() + ".txt");
 			if(!proofFile.exists())
 				proofFile.createNewFile();
 			proofFileHandler = new FileHandle(proofFile);

--- a/common/src/com/elikill58/negativity/common/timers/AnalyzePacketTimer.java
+++ b/common/src/com/elikill58/negativity/common/timers/AnalyzePacketTimer.java
@@ -76,7 +76,6 @@ public class AnalyzePacketTimer implements Runnable {
 			
 			np.MOVE_TIME = 0;
 			np.clearPackets();
-			np.saveProof(); // TODO don't write all files at same time
 		}
 	}
 }

--- a/common/src/com/elikill58/negativity/universal/Negativity.java
+++ b/common/src/com/elikill58/negativity/universal/Negativity.java
@@ -3,6 +3,7 @@ package com.elikill58.negativity.universal;
 import static com.elikill58.negativity.universal.verif.VerificationManager.hasVerifications;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.sql.Timestamp;
 import java.util.Collections;
 import java.util.HashSet;
@@ -34,6 +35,7 @@ import com.elikill58.negativity.universal.ban.BanUtils;
 import com.elikill58.negativity.universal.bedrock.BedrockPlayerManager;
 import com.elikill58.negativity.universal.bypass.BypassManager;
 import com.elikill58.negativity.universal.dataStorage.NegativityAccountStorage;
+import com.elikill58.negativity.universal.file.FileSaverTimer;
 import com.elikill58.negativity.universal.multiVersion.PlayerVersionManager;
 import com.elikill58.negativity.universal.permissions.Perm;
 import com.elikill58.negativity.universal.playerModifications.PlayerModificationsManager;
@@ -342,6 +344,13 @@ public class Negativity {
 				NegativityPlayer.getNegativityPlayer(p).setClientName(new String(msg).substring(1));
 			});
 			initAlertShower(ada);
+			try {
+				// Create proof folder at startup to don't check after
+				Files.createDirectories(Adapter.getAdapter().getDataFolder().getAbsoluteFile().toPath().resolve("user").resolve("proof"));
+				ada.getScheduler().runRepeatingAsync(new FileSaverTimer(), 20);
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
 		}
 		UniversalUtils.init();
 		

--- a/common/src/com/elikill58/negativity/universal/Negativity.java
+++ b/common/src/com/elikill58/negativity/universal/Negativity.java
@@ -347,7 +347,11 @@ public class Negativity {
 			try {
 				// Create proof folder at startup to don't check after
 				Files.createDirectories(Adapter.getAdapter().getDataFolder().getAbsoluteFile().toPath().resolve("user").resolve("proof"));
-				ada.getScheduler().runRepeatingAsync(new FileSaverTimer(), 20);
+				FileSaverTimer old = FileSaverTimer.getInstance();
+				if(old != null)
+					old.runAll();
+				else
+					ada.getScheduler().runRepeatingAsync(new FileSaverTimer(), 20);
 			} catch (IOException e) {
 				e.printStackTrace();
 			}

--- a/common/src/com/elikill58/negativity/universal/Negativity.java
+++ b/common/src/com/elikill58/negativity/universal/Negativity.java
@@ -3,7 +3,6 @@ package com.elikill58.negativity.universal;
 import static com.elikill58.negativity.universal.verif.VerificationManager.hasVerifications;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.sql.Timestamp;
 import java.util.Collections;
 import java.util.HashSet;
@@ -344,17 +343,11 @@ public class Negativity {
 				NegativityPlayer.getNegativityPlayer(p).setClientName(new String(msg).substring(1));
 			});
 			initAlertShower(ada);
-			try {
-				// Create proof folder at startup to don't check after
-				Files.createDirectories(Adapter.getAdapter().getDataFolder().getAbsoluteFile().toPath().resolve("user").resolve("proof"));
-				FileSaverTimer old = FileSaverTimer.getInstance();
-				if(old != null)
-					old.runAll();
-				else
-					ada.getScheduler().runRepeatingAsync(new FileSaverTimer(), 20);
-			} catch (IOException e) {
-				e.printStackTrace();
-			}
+			FileSaverTimer old = FileSaverTimer.getInstance();
+			if(old != null)
+				old.runAll();
+			else
+				ada.getScheduler().runRepeatingAsync(new FileSaverTimer(), 20);
 		}
 		UniversalUtils.init();
 		

--- a/common/src/com/elikill58/negativity/universal/Scheduler.java
+++ b/common/src/com/elikill58/negativity/universal/Scheduler.java
@@ -8,6 +8,14 @@ public interface Scheduler {
 	
 	void runRepeating(Consumer<ScheduledTask> task, int delayTicks, int intervalTicks);
 	
+	/**
+	 * Run the given task each given ticks, after waiting a delay
+	 * 
+	 * @param task task to run
+	 * @param delayTicks delay before starting task
+	 * @param intervalTicks ticks between each task runned
+	 * @return the running task
+	 */
 	ScheduledTask runRepeating(Runnable task, int delayTicks, int intervalTicks);
 	
 	default ScheduledTask runRepeating(Runnable task, int intervalTicks) {
@@ -16,6 +24,19 @@ public interface Scheduler {
 	
 	ScheduledTask runRepeating(Runnable task, int intervalTicks, @Nullable String name);
 	
+	default ScheduledTask runRepeatingAsync(Runnable task, int intervalTicks) {
+		return runRepeatingAsync(task, intervalTicks, null);
+	}
+	
+	ScheduledTask runRepeatingAsync(Runnable task, int intervalTicks, @Nullable String name);
+	
+	/**
+	 * Run task after waiting given ticks
+	 * 
+	 * @param task task to run
+	 * @param delayTicks ticks before running task
+	 * @return the running task
+	 */
 	ScheduledTask runDelayed(Runnable task, int delayTicks);
 	
 	static Scheduler getInstance() {

--- a/common/src/com/elikill58/negativity/universal/file/FileHandle.java
+++ b/common/src/com/elikill58/negativity/universal/file/FileHandle.java
@@ -1,0 +1,48 @@
+package com.elikill58.negativity.universal.file;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class FileHandle {
+
+	public static final List<FileHandle> FILE_HANDLES = new ArrayList<>();
+	public static final long MAX_TIME = 10000; // 1000 = 1 second
+	private final FileWriter handle;
+	private boolean closed = false;
+	private long lastUpdate;
+	
+	public FileHandle(File file) throws IOException {
+		this.handle = new FileWriter(file);
+		this.lastUpdate = System.currentTimeMillis();
+	}
+	
+	public void update() {
+		this.lastUpdate = System.currentTimeMillis();
+	}
+	
+	public boolean isClosed() {
+		return handle == null || closed;
+	}
+	
+	public void write(List<String> lines) throws IOException {
+		for(String s : lines)
+			handle.append(s + "\n");
+	}
+	
+	public boolean shouldBeClosed() {
+		return !isClosed() && System.currentTimeMillis() - lastUpdate > MAX_TIME;
+	}
+	
+	public void close() {
+		closed = true;
+		try {
+			handle.close();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		FILE_HANDLES.remove(this);
+	}
+}

--- a/common/src/com/elikill58/negativity/universal/file/FileHandle.java
+++ b/common/src/com/elikill58/negativity/universal/file/FileHandle.java
@@ -8,15 +8,19 @@ import java.util.List;
 
 public class FileHandle {
 
-	public static final List<FileHandle> FILE_HANDLES = new ArrayList<>();
-	public static final long MAX_TIME = 10000; // 1000 = 1 second
+	private static final List<FileHandle> FILE_HANDLES = new ArrayList<>();
+	public static List<FileHandle> getFileHandles() {
+		return FILE_HANDLES;
+	}
+	private static final long MAX_TIME = 10000; // 1000 = 1 second
 	private final FileWriter handle;
 	private boolean closed = false;
 	private long lastUpdate;
 	
 	public FileHandle(File file) throws IOException {
-		this.handle = new FileWriter(file);
+		this.handle = new FileWriter(file, true);
 		this.lastUpdate = System.currentTimeMillis();
+		FILE_HANDLES.add(this);
 	}
 	
 	public void update() {

--- a/common/src/com/elikill58/negativity/universal/file/FileHandle.java
+++ b/common/src/com/elikill58/negativity/universal/file/FileHandle.java
@@ -1,8 +1,10 @@
 package com.elikill58.negativity.universal.file;
 
-import java.io.File;
-import java.io.FileWriter;
+import java.io.BufferedWriter;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -13,12 +15,12 @@ public class FileHandle {
 		return FILE_HANDLES;
 	}
 	private static final long MAX_TIME = 10000; // 1000 = 1 second
-	private final FileWriter handle;
+	private final BufferedWriter handle;
 	private boolean closed = false;
 	private long lastUpdate;
 	
-	public FileHandle(File file) throws IOException {
-		this.handle = new FileWriter(file, true);
+	public FileHandle(Path file) throws IOException {
+		this.handle = Files.newBufferedWriter(file, StandardOpenOption.APPEND);
 		this.lastUpdate = System.currentTimeMillis();
 		FILE_HANDLES.add(this);
 	}

--- a/common/src/com/elikill58/negativity/universal/file/FileSaverAction.java
+++ b/common/src/com/elikill58/negativity/universal/file/FileSaverAction.java
@@ -3,7 +3,7 @@ package com.elikill58.negativity.universal.file;
 public interface FileSaverAction {
 
     /**
-     * Technically save the save sync with the thread which run this
+     * Save informations sync with current thread
      * 
      * @param finished the action to run when it's finished
      */

--- a/common/src/com/elikill58/negativity/universal/file/FileSaverAction.java
+++ b/common/src/com/elikill58/negativity/universal/file/FileSaverAction.java
@@ -1,0 +1,11 @@
+package com.elikill58.negativity.universal.file;
+
+public interface FileSaverAction {
+
+    /**
+     * Technically save the save sync with the thread which run this
+     * 
+     * @param finished the action to run when it's finished
+     */
+    void save(FileSaverTimer timer);
+}

--- a/common/src/com/elikill58/negativity/universal/file/FileSaverTimer.java
+++ b/common/src/com/elikill58/negativity/universal/file/FileSaverTimer.java
@@ -12,7 +12,7 @@ public class FileSaverTimer implements Runnable {
 	public static FileSaverTimer getInstance() {
 		return instance;
 	}
-    public static final int MAX_RUNNING = 10, SKIP_WHEN_ALREADY = 2;
+	private static final int MAX_RUNNING = 10, SKIP_WHEN_ALREADY = 2;
     private final List<FileSaverAction> allActions = new ArrayList<>();
     public void addAction(FileSaverAction action) {
         allActions.add(action);
@@ -40,10 +40,7 @@ public class FileSaverTimer implements Runnable {
         
         // now check for old handle
         NegativityPlayer.getAllNegativityPlayers().forEach(NegativityPlayer::checkProofFileHandler);
-        FileHandle.FILE_HANDLES.forEach((fh) -> {
-			if(fh.shouldBeClosed())
-				fh.close();
-        });
+        FileHandle.getFileHandles().stream().filter(FileHandle::shouldBeClosed).forEach(FileHandle::close);
     }
     
     public void runAll() {

--- a/common/src/com/elikill58/negativity/universal/file/FileSaverTimer.java
+++ b/common/src/com/elikill58/negativity/universal/file/FileSaverTimer.java
@@ -1,0 +1,52 @@
+package com.elikill58.negativity.universal.file;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.elikill58.negativity.api.NegativityPlayer;
+import com.elikill58.negativity.universal.Adapter;
+
+public class FileSaverTimer implements Runnable {
+
+	private static FileSaverTimer instance;
+	public static FileSaverTimer getInstance() {
+		return instance;
+	}
+    public static final int MAX_RUNNING = 10, SKIP_WHEN_ALREADY = 2;
+    private final List<FileSaverAction> allActions = new ArrayList<>();
+    public void addAction(FileSaverAction action) {
+        allActions.add(action);
+    }
+    
+    private int actionRunning = 0;
+    
+    public FileSaverTimer() {
+    	if(instance != null) {
+    		Adapter.getAdapter().getLogger().error("Another instance of FileSaveTimer is created even if an old already exist");
+    		return;
+    	}
+    	instance = this;
+    }
+    
+    @Override
+    public void run() {
+        if(actionRunning < SKIP_WHEN_ALREADY) {
+	        for(int i = actionRunning; !allActions.isEmpty() && i < MAX_RUNNING; i++) {
+	            FileSaverAction action = allActions.remove(0); // removing first item
+	            actionRunning++; // adding a running task
+	            action.save(this); // save, and when it's finished removing running task
+			}
+        }// too many already running, skipping save of others ...
+        
+        // now check for old handle
+        NegativityPlayer.getAllNegativityPlayers().forEach(NegativityPlayer::checkProofFileHandler);
+        FileHandle.FILE_HANDLES.forEach((fh) -> {
+			if(fh.shouldBeClosed())
+				fh.close();
+        });
+    }
+
+    public void removeActionRunning() {
+    	actionRunning--;
+    }
+}

--- a/common/src/com/elikill58/negativity/universal/file/FileSaverTimer.java
+++ b/common/src/com/elikill58/negativity/universal/file/FileSaverTimer.java
@@ -1,5 +1,7 @@
 package com.elikill58.negativity.universal.file;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -30,6 +32,11 @@ public class FileSaverTimer implements Runnable {
     
     @Override
     public void run() {
+		try {
+			Files.createDirectories(Adapter.getAdapter().getDataFolder().getAbsoluteFile().toPath().resolve("user").resolve("proof"));
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
         if(actionRunning < SKIP_WHEN_ALREADY) {
 	        for(int i = 0; !allActions.isEmpty() && i < MAX_RUNNING; i++) {
 	            FileSaverAction action = allActions.remove(0); // removing first item

--- a/common/src/com/elikill58/negativity/universal/file/FileSaverTimer.java
+++ b/common/src/com/elikill58/negativity/universal/file/FileSaverTimer.java
@@ -31,7 +31,7 @@ public class FileSaverTimer implements Runnable {
     @Override
     public void run() {
         if(actionRunning < SKIP_WHEN_ALREADY) {
-	        for(int i = actionRunning; !allActions.isEmpty() && i < MAX_RUNNING; i++) {
+	        for(int i = 0; !allActions.isEmpty() && i < MAX_RUNNING; i++) {
 	            FileSaverAction action = allActions.remove(0); // removing first item
 	            actionRunning++; // adding a running task
 	            action.save(this); // save, and when it's finished removing running task
@@ -44,6 +44,10 @@ public class FileSaverTimer implements Runnable {
 			if(fh.shouldBeClosed())
 				fh.close();
         });
+    }
+    
+    public void runAll() {
+    	allActions.forEach((a) -> a.save(this));
     }
 
     public void removeActionRunning() {

--- a/common/src/com/elikill58/negativity/universal/file/hook/DefaultFileSaverAction.java
+++ b/common/src/com/elikill58/negativity/universal/file/hook/DefaultFileSaverAction.java
@@ -1,0 +1,31 @@
+package com.elikill58.negativity.universal.file.hook;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+
+import com.elikill58.negativity.universal.file.FileSaverAction;
+import com.elikill58.negativity.universal.file.FileSaverTimer;
+
+public class DefaultFileSaverAction implements FileSaverAction {
+
+	private final File file;
+	private final String content;
+	
+	public DefaultFileSaverAction(File file, String content) {
+		this.file = file;
+		this.content = content;
+	}
+	
+	@Override
+	public void save(FileSaverTimer timer) {
+        try {
+            Files.write(file.toPath(), content.getBytes(), StandardOpenOption.APPEND);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    	
+    	timer.removeActionRunning();
+    }
+}

--- a/common/src/com/elikill58/negativity/universal/file/hook/DefaultFileSaverAction.java
+++ b/common/src/com/elikill58/negativity/universal/file/hook/DefaultFileSaverAction.java
@@ -1,8 +1,8 @@
 package com.elikill58.negativity.universal.file.hook;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 
 import com.elikill58.negativity.universal.file.FileSaverAction;
@@ -10,10 +10,10 @@ import com.elikill58.negativity.universal.file.FileSaverTimer;
 
 public class DefaultFileSaverAction implements FileSaverAction {
 
-	private final File file;
+	private final Path file;
 	private final String content;
 	
-	public DefaultFileSaverAction(File file, String content) {
+	public DefaultFileSaverAction(Path file, String content) {
 		this.file = file;
 		this.content = content;
 	}
@@ -21,7 +21,7 @@ public class DefaultFileSaverAction implements FileSaverAction {
 	@Override
 	public void save(FileSaverTimer timer) {
         try {
-            Files.write(file.toPath(), content.getBytes(), StandardOpenOption.APPEND);
+            Files.write(file, content.getBytes(), StandardOpenOption.APPEND);
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/spigot/src/com/elikill58/negativity/spigot/SpigotScheduler.java
+++ b/spigot/src/com/elikill58/negativity/spigot/SpigotScheduler.java
@@ -41,6 +41,11 @@ public class SpigotScheduler implements Scheduler {
 	}
 	
 	@Override
+	public ScheduledTask runRepeatingAsync(Runnable task, int intervalTicks, @Nullable String name) {
+		return new TaskWrapper(Bukkit.getScheduler().runTaskTimerAsynchronously(this.plugin, task, 0, intervalTicks));
+	}
+	
+	@Override
 	public ScheduledTask runDelayed(Runnable task, int delayTicks) {
 		return new TaskWrapper(Bukkit.getScheduler().runTaskLater(this.plugin, task, delayTicks));
 	}

--- a/sponge/src/com/elikill58/negativity/sponge/SpongeScheduler.java
+++ b/sponge/src/com/elikill58/negativity/sponge/SpongeScheduler.java
@@ -36,6 +36,15 @@ public class SpongeScheduler implements Scheduler {
 	}
 	
 	@Override
+	public ScheduledTask runRepeatingAsync(Runnable task, int intervalTicks, @Nullable String name) {
+		Task.Builder builder = Task.builder().execute(task).async().intervalTicks(intervalTicks);
+		if (name != null) {
+			builder.name(name);
+		}
+		return new TaskWrapper(builder.submit(this.plugin));
+	}
+	
+	@Override
 	public ScheduledTask runDelayed(Runnable task, int delayTicks) {
 		return new TaskWrapper(Task.builder().execute(task).delayTicks(delayTicks).submit(this.plugin));
 	}


### PR DESCRIPTION
The objective was to clean how proof files are saved. Before, they was just all saved each seconds, at same time.

Maybe we should put `MAX_RUNNING` and `SKIP_WHEN_ALREADY` in config. Also, ALL files are saved (async) when stopping server/reloading negativity.

More informations about why this code [here](https://codereview.stackexchange.com/q/269206/244108).