### PR TITLE
fix NoSuchMethodException

### DIFF
--- a/spigot/src/com/elikill58/negativity/spigot/scheduler/FoliaScheduler.java
+++ b/spigot/src/com/elikill58/negativity/spigot/scheduler/FoliaScheduler.java
@@ -100,8 +100,8 @@ public class FoliaScheduler implements Scheduler {
 	public ScheduledTask runEntityDelayed(Entity entity, Runnable task, int delayTicks) {
 		try {
 			Object scheduler = getEntityScheduler(entity);
-			Method method = scheduler.getClass().getDeclaredMethod("runDelayed", Plugin.class, Consumer.class, long.class);
-			return new TaskWrapper(method.invoke(scheduler, this.plugin, (Consumer<?>) (scheduledTask) -> task.run(), delayTicks));
+			Method method = scheduler.getClass().getDeclaredMethod("runDelayed", Plugin.class, Consumer.class, Runnable.class ,long.class);
+			return new TaskWrapper(method.invoke(scheduler, this.plugin, (Consumer<?>) (scheduledTask) -> task.run(), null, delayTicks));
 		} catch (Exception e) {
 			e.printStackTrace();
 		}


### PR DESCRIPTION
`[09:28:47] [Region Scheduler Thread #0/WARN]: java.lang.NoSuchMethodException: io.papermc.paper.threadedregions.scheduler.FoliaEntityScheduler.runDelayed(org.bukkit.plugin.Plugin,null,java.util.function.Consumer,long)
[09:28:47] [Region Scheduler Thread #0/WARN]: 	at java.base/java.lang.Class.getDeclaredMethod(Class.java:2728)
[09:28:47] [Region Scheduler Thread #0/WARN]: 	at Negativity-2.7-SNAPSHOT.jar//com.elikill58.negativity.spigot.scheduler.FoliaScheduler.runEntityDelayed(FoliaScheduler.java:103)
[09:28:47] [Region Scheduler Thread #0/WARN]: 	at Negativity-2.7-SNAPSHOT.jar//com.elikill58.negativity.common.protocols.AirJump.onMove(AirJump.java:48)
[09:28:47] [Region Scheduler Thread #0/WARN]: 	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
[09:28:47] [Region Scheduler Thread #0/WARN]: 	at java.base/java.lang.reflect.Method.invoke(Method.java:578)
[09:28:47] [Region Scheduler Thread #0/WARN]: 	at Negativity-2.7-SNAPSHOT.jar//com.elikill58.negativity.api.protocols.CheckManager$CheckMethod.invoke(CheckManager.java:131)
[09:28:47] [Region Scheduler Thread #0/WARN]: 	at Negativity-2.7-SNAPSHOT.jar//com.elikill58.negativity.api.protocols.CheckManager.lambda$onPlayerEvent$2(CheckManager.java:82)
[09:28:47] [Region Scheduler Thread #0/WARN]: 	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
[09:28:47] [Region Scheduler Thread #0/WARN]: 	at Negativity-2.7-SNAPSHOT.jar//com.elikill58.negativity.api.protocols.CheckManager.onPlayerEvent(CheckManager.java:65)
[09:28:47] [Region Scheduler Thread #0/WARN]: 	at Negativity-2.7-SNAPSHOT.jar//com.elikill58.negativity.api.events.EventManager$HandleBasedListener.call(EventManager.java:233)
[09:28:47] [Region Scheduler Thread #0/WARN]: 	at Negativity-2.7-SNAPSHOT.jar//com.elikill58.negativity.api.events.EventManager.lambda$callEvent$1(EventManager.java:175)
[09:28:47] [Region Scheduler Thread #0/WARN]: 	at java.base/java.util.HashMap.forEach(HashMap.java:1429)
[09:28:47] [Region Scheduler Thread #0/WARN]: 	at Negativity-2.7-SNAPSHOT.jar//com.elikill58.negativity.api.events.EventManager.callEvent(EventManager.java:171)
[09:28:47] [Region Scheduler Thread #0/WARN]: 	at Negativity-2.7-SNAPSHOT.jar//com.elikill58.negativity.api.events.EventManager.callEvent(EventManager.java:158)
[09:28:47] [Region Scheduler Thread #0/WARN]: 	at Negativity-2.7-SNAPSHOT.jar//com.elikill58.negativity.common.server.NegativityPacketInListener.onPacketReceive(NegativityPacketInListener.java:72)
[09:28:47] [Region Scheduler Thread #0/WARN]: 	at Negativity-2.7-SNAPSHOT.jar//com.elikill58.negativity.api.events.EventManager$HandleBasedListener.call(EventManager.java:233)
[09:28:47] [Region Scheduler Thread #0/WARN]: 	at Negativity-2.7-SNAPSHOT.jar//com.elikill58.negativity.api.events.EventManager.lambda$callEvent$1(EventManager.java:175)
[09:28:47] [Region Scheduler Thread #0/WARN]: 	at java.base/java.util.HashMap.forEach(HashMap.java:1429)
[09:28:47] [Region Scheduler Thread #0/WARN]: 	at Negativity-2.7-SNAPSHOT.jar//com.elikill58.negativity.api.events.EventManager.callEvent(EventManager.java:171)
[09:28:47] [Region Scheduler Thread #0/WARN]: 	at Negativity-2.7-SNAPSHOT.jar//com.elikill58.negativity.api.events.EventManager.callEvent(EventManager.java:156)
[09:28:47] [Region Scheduler Thread #0/WARN]: 	at Negativity-2.7-SNAPSHOT.jar//com.elikill58.negativity.api.packets.nms.channels.netty.NettyDecoderHandler.lambda$channelRead$0(NettyDecoderHandler.java:55)
[09:28:47] [Region Scheduler Thread #0/WARN]: 	at Negativity-2.7-SNAPSHOT.jar//com.elikill58.negativity.spigot.scheduler.FoliaScheduler.lambda$runEntity$1(FoliaScheduler.java:44)
[09:28:47] [Region Scheduler Thread #0/WARN]: 	at io.papermc.paper.threadedregions.scheduler.FoliaEntityScheduler$EntityScheduledTask.accept(FoliaEntityScheduler.java:168)
[09:28:47] [Region Scheduler Thread #0/WARN]: 	at io.papermc.paper.threadedregions.scheduler.FoliaEntityScheduler$EntityScheduledTask.accept(FoliaEntityScheduler.java:115)
[09:28:47] [Region Scheduler Thread #0/WARN]: 	at io.papermc.paper.threadedregions.EntityScheduler.executeTick(EntityScheduler.java:173)
[09:28:47] [Region Scheduler Thread #0/WARN]: 	at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1532)
[09:28:47] [Region Scheduler Thread #0/WARN]: 	at io.papermc.paper.threadedregions.TickRegions$ConcreteRegionTickHandle.tickRegion(TickRegions.java:406)
[09:28:47] [Region Scheduler Thread #0/WARN]: 	at io.papermc.paper.threadedregions.TickRegionScheduler$RegionScheduleHandle.runTick(TickRegionScheduler.java:391)
[09:28:47] [Region Scheduler Thread #0/WARN]: 	at ca.spottedleaf.concurrentutil.scheduler.SchedulerThreadPool$TickThreadRunner.run(SchedulerThreadPool.java:540)
[09:28:47] [Region Scheduler Thread #0/WARN]: 	at java.base/java.lang.Thread.run(Thread.java:1589)
`